### PR TITLE
feat: list_folders and create_folder (v0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **read_jira_issue** | Get JIRA issue details (optional fields). |
 | **create_test_plan** / **list_test_plans** | Create and list test plans. |
 | **create_test_cycle** / **list_test_cycles** | Create and list test cycles. |
+| **list_folders** / **create_folder** | List and create folders (for organizing test cases or test cycles). Filter by folderType (TEST_CASE / TEST_CYCLE) and parentId for subfolders. |
 | **list_test_executions_in_cycle** | List test cases and executions in a cycle. |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
@@ -133,6 +134,14 @@ list_test_executions_in_cycle({ cycleId: "ABC-R1" });
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
 create_test_execution({ projectKey: "ABC", testCycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
+```
+
+**Folders**
+```ts
+list_folders({ projectKey: "ABC", folderType: "TEST_CASE", limit: 50 });
+list_folders({ projectKey: "ABC", parentId: 12345 });  // subfolders of folder 12345
+create_folder({ projectKey: "ABC", name: "Regression", folderType: "TEST_CASE" });
+create_folder({ projectKey: "ABC", name: "Subfolder", parentId: 12345 });
 ```
 
 **Test cases**
@@ -209,7 +218,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **List test cases or executions in a cycle** — `list_test_executions_in_cycle` lists executions in a cycle (by cycle id/key).
 - [x] **Create test execution** — `create_test_execution` creates a test execution (e.g. add test case to cycle with status “Not Executed”).
 - [ ] **Get single test plan / test cycle** — Fetch one plan or cycle by key/id (today only list is exposed).
-- [ ] **Folders** — List and create folders (today `folderId` is accepted but folders cannot be listed or created).
+- [x] **Folders** — `list_folders` and `create_folder` (filter by folderType, parentId for hierarchy).
 - [ ] **Zephyr projects list** — List projects from Zephyr API for projectKey discovery.
 - [ ] **Priorities and statuses** — List valid priority/status values for test cases.
 - [ ] **Environments** — List or manage environments for cycles.

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -12,6 +12,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | **Test cycles** | Create, list (by projectKey, optional versionId) |
 | **Test executions** | Create (add test case to cycle), get one, update status/comment/defects, list in cycle, summary by cycle |
 | **Test cases** | Get one, search, create, update, create multiple |
+| **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
 | **Links** | Link test case to Jira issue(s) (POST testcases/{id}/links) |
 | **Reporting** | Generate test report for a cycle (JSON/HTML) |
 
@@ -48,8 +49,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 6. **Folders**
 
-- **API:** Folder endpoints for organizing test cases (list/create folders, possibly update/delete if documented).
-- **Gap:** Test cases can be created with `folderId`, but there is no tool to list folders or create a folder. Users cannot discover valid `folderId` values or create structure via MCP.
+- **API:** `GET /folders` (projectKey, folderType, parentId, pagination), `POST /folders` (projectKey, name, parentId?, folderType?).
+- **MCP status:** Implemented (`list_folders`, `create_folder`). List with optional folderType (TEST_CASE / TEST_CYCLE) and parentId for subfolders; create with optional parentId and folderType. Enables coherent folder structure for test cases and cycles; use returned folder `id` as `folderId` when creating/updating test cases.
 - **Ref:** [Community: folder/test case delete](https://community.smartbear.com/discussions/zephyrscale/zephyr-scale-api---how-to-delete-folder--test-case/266801)
 
 ### 7. **Zephyr projects**
@@ -104,7 +105,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 3 | Get test cycle by key/id | GET testcycles/{key} | Not implemented |
 | 4 | List test cases/executions in cycle | GET testexecutions?testCycle=... | Implemented |
 | 5 | Create test execution | POST testexecutions | Implemented (workaround for add-to-cycle on EU) |
-| 6 | List/create folders | GET/POST folders | Not implemented |
+| 6 | List/create folders | GET/POST folders | Implemented |
 | 7 | List Zephyr projects | GET projects | Not implemented |
 | 8 | List priorities/statuses | GET priorities, statuses | Not implemented |
 | 9 | List/manage environments | GET (environments) | Not implemented |

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -7,6 +7,7 @@ import {
   ZephyrTestCase,
   ZephyrTestReport,
   ZephyrExecutionSummary,
+  ZephyrFolder,
 } from '../types/zephyr-types.js';
 
 export class ZephyrClient {
@@ -95,6 +96,55 @@ export class ZephyrClient {
       testCycles,
       total: response.data.total ?? testCycles.length,
     };
+  }
+
+  async getFolders(projectKey: string, options?: {
+    folderType?: 'TEST_CASE' | 'TEST_CYCLE';
+    parentId?: number | null;
+    limit?: number;
+    startAt?: number;
+  }): Promise<{ folders: ZephyrFolder[]; total: number }> {
+    const params: Record<string, string | number | undefined> = {
+      projectKey,
+      maxResults: options?.limit ?? 50,
+      startAt: options?.startAt ?? 0,
+    };
+    if (options?.folderType) {
+      params.folderType = options.folderType;
+    }
+    if (options?.parentId != null) {
+      params.parentId = options.parentId;
+    }
+    const response = await this.client.get('/folders', { params });
+    const folders = Array.isArray(response.data.values)
+      ? response.data.values
+      : Array.isArray(response.data)
+        ? response.data
+        : [];
+    return {
+      folders: folders as ZephyrFolder[],
+      total: response.data.total ?? folders.length,
+    };
+  }
+
+  async createFolder(data: {
+    projectKey: string;
+    name: string;
+    parentId?: number | null;
+    folderType?: 'TEST_CASE' | 'TEST_CYCLE';
+  }): Promise<ZephyrFolder> {
+    const payload: Record<string, string | number | null | undefined> = {
+      projectKey: data.projectKey,
+      name: data.name,
+    };
+    if (data.parentId != null) {
+      payload.parentId = data.parentId;
+    }
+    if (data.folderType) {
+      payload.folderType = data.folderType;
+    }
+    const response = await this.client.post('/folders', payload);
+    return response.data;
   }
 
   async addTestCasesToCycle(cycleKey: string, testCaseKeys: string[]): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   generateTestReport,
 } from './tools/test-execution.js';
 import { createTestCase, searchTestCases, getTestCase, updateTestCase, createMultipleTestCases } from './tools/test-cases.js';
+import { listFolders, createFolder } from './tools/folders.js';
 import {
   readJiraIssueSchema,
   createTestPlanSchema,
@@ -30,6 +31,8 @@ import {
   listTestExecutionsInCycleSchema,
   addTestCasesToCycleSchema,
   createTestExecutionSchema,
+  listFoldersSchema,
+  createFolderSchema,
   linkTestsToIssuesSchema,
   generateTestReportSchema,
   createTestCaseSchema,
@@ -47,6 +50,8 @@ import {
   ListTestExecutionsInCycleInput,
   AddTestCasesToCycleInput,
   CreateTestExecutionInput,
+  ListFoldersInput,
+  CreateFolderInput,
   LinkTestsToIssuesInput,
   GenerateTestReportInput,
   CreateTestCaseInput,
@@ -226,6 +231,35 @@ const TOOLS = [
         format: { type: 'string', enum: ['JSON', 'HTML'], description: 'Report format (default: JSON)' },
       },
       required: ['cycleId'],
+    },
+  },
+  {
+    name: 'list_folders',
+    description: 'List folders in a project (for organizing test cases or test cycles). Optionally filter by type and parent folder.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key' },
+        folderType: { type: 'string', enum: ['TEST_CASE', 'TEST_CYCLE'], description: 'Filter by folder type (optional)' },
+        parentId: { type: 'number', description: 'List only children of this folder ID (optional)' },
+        limit: { type: 'number', description: 'Max results (default: 50)' },
+        startAt: { type: 'number', description: 'Offset for pagination (default: 0)' },
+      },
+      required: ['projectKey'],
+    },
+  },
+  {
+    name: 'create_folder',
+    description: 'Create a folder in a project (for organizing test cases or test cycles). Use parentId for subfolders.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key' },
+        name: { type: 'string', description: 'Folder name' },
+        parentId: { type: 'number', description: 'Parent folder ID for subfolders (optional)' },
+        folderType: { type: 'string', enum: ['TEST_CASE', 'TEST_CYCLE'], description: 'Folder type (optional; default may be TEST_CASE)' },
+      },
+      required: ['projectKey', 'name'],
     },
   },
   {
@@ -556,6 +590,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await generateTestReport(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_folders': {
+        const validatedArgs = validateInput<ListFoldersInput>(listFoldersSchema, args, 'list_folders');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await listFolders(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'create_folder': {
+        const validatedArgs = validateInput<CreateFolderInput>(createFolderSchema, args, 'create_folder');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await createFolder(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -1,0 +1,76 @@
+import { ZephyrClient } from '../clients/zephyr-client.js';
+import {
+  listFoldersSchema,
+  createFolderSchema,
+  ListFoldersInput,
+  CreateFolderInput,
+} from '../utils/validation.js';
+
+let zephyrClient: ZephyrClient | null = null;
+
+const getZephyrClient = (): ZephyrClient => {
+  if (!zephyrClient) {
+    zephyrClient = new ZephyrClient();
+  }
+  return zephyrClient;
+};
+
+export const listFolders = async (input: ListFoldersInput) => {
+  const validatedInput = listFoldersSchema.parse(input);
+  try {
+    const result = await getZephyrClient().getFolders(validatedInput.projectKey, {
+      folderType: validatedInput.folderType,
+      parentId: validatedInput.parentId,
+      limit: validatedInput.limit,
+      startAt: validatedInput.startAt,
+    });
+    return {
+      success: true,
+      data: {
+        total: result.total,
+        folders: result.folders.map((f: any) => ({
+          id: f.id,
+          name: f.name,
+          projectKey: f.projectKey ?? f.projectId,
+          parentId: f.parentId ?? null,
+          type: f.type ?? f.folderType,
+          self: f.self,
+          folders: f.folders,
+        })),
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const createFolder = async (input: CreateFolderInput) => {
+  const validatedInput = createFolderSchema.parse(input);
+  try {
+    const folder = await getZephyrClient().createFolder({
+      projectKey: validatedInput.projectKey,
+      name: validatedInput.name,
+      parentId: validatedInput.parentId,
+      folderType: validatedInput.folderType,
+    });
+    return {
+      success: true,
+      data: {
+        id: folder.id,
+        name: folder.name,
+        projectKey: folder.projectKey ?? folder.projectId,
+        parentId: folder.parentId ?? null,
+        type: folder.type,
+        self: folder.self,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -106,6 +106,17 @@ export interface ZephyrTestCase {
   };
 }
 
+export interface ZephyrFolder {
+  id: number;
+  name: string;
+  projectKey?: string;
+  projectId?: number;
+  parentId?: number | null;
+  type?: 'TEST_CASE' | 'TEST_CYCLE';
+  self?: string;
+  folders?: ZephyrFolder[];
+}
+
 export interface ZephyrExecutionSummary {
   total: number;
   passed: number;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -55,6 +55,24 @@ export const addTestCasesToCycleSchema = z.object({
   testCaseKeys: z.array(z.string().min(1)).min(1, 'At least one test case key is required'),
 });
 
+export const listFoldersSchema = z.object({
+  projectKey: z.string().min(1, 'Project key is required'),
+  folderType: z.enum(['TEST_CASE', 'TEST_CYCLE']).optional(),
+  parentId: z.number().int().min(0).optional().nullable(),
+  limit: z.number().min(1).max(100).default(50),
+  startAt: z.number().min(0).default(0),
+});
+
+export const createFolderSchema = z.object({
+  projectKey: z.string().min(1, 'Project key is required'),
+  name: z.string().min(1, 'Folder name is required'),
+  parentId: z.number().int().min(0).optional().nullable(),
+  folderType: z.enum(['TEST_CASE', 'TEST_CYCLE']).optional(),
+});
+
+export type ListFoldersInput = z.infer<typeof listFoldersSchema>;
+export type CreateFolderInput = z.infer<typeof createFolderSchema>;
+
 export const createTestExecutionSchema = z.object({
   projectKey: z.string().min(1, 'Project key is required'),
   testCaseKey: z.string().min(1, 'Test case key is required'),


### PR DESCRIPTION
## Summary

Adds folder support so the MCP can maintain a coherent folder structure for test cases and test cycles.

## Tools

- **list_folders** — List folders in a project. Optional: `folderType` (TEST_CASE / TEST_CYCLE), `parentId` (children of a folder), `limit`, `startAt`.
- **create_folder** — Create a folder. Required: `projectKey`, `name`. Optional: `parentId` (for subfolders), `folderType`.

## Changes

- **Zephyr client:** `getFolders()`, `createFolder()` — GET/POST `/folders` with projectKey, folderType, parentId, pagination.
- **Types:** `ZephyrFolder` in zephyr-types.ts.
- **Validation:** `listFoldersSchema`, `createFolderSchema`.
- **Docs:** README (tools table, Folders examples, roadmap), ZEPHYR-SCALE-CLOUD-API-GAPS.md (folders implemented).

## Testing

Verified on CP project (EU API):
- list_folders (CP) → 197 folders, hierarchy via parentId.
- list_folders (CP, folderType: TEST_CASE) → 195 TEST_CASE folders.
- create_folder (CP, "MCP folder test", TEST_CASE) → id 415796, appears in list.
- Pagination (startAt, limit) works.