### PR TITLE
feat: test cycle folder and update_test_cycle

### DIFF
--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -62,11 +62,12 @@ export class ZephyrClient {
     description?: string;
     projectKey: string;
     versionId: string;
+    folderId?: string | number;
     environment?: string;
     startDate?: string;
     endDate?: string;
   }): Promise<ZephyrTestCycle> {
-    const payload = {
+    const payload: Record<string, unknown> = {
       name: data.name,
       description: data.description,
       projectKey: data.projectKey,
@@ -75,8 +76,37 @@ export class ZephyrClient {
       plannedStartDate: data.startDate,
       plannedEndDate: data.endDate,
     };
+    if (data.folderId != null) {
+      payload.folderId = data.folderId;
+    }
 
     const response = await this.client.post('/testcycles', payload);
+    return response.data;
+  }
+
+  async updateTestCycle(cycleKey: string, data: {
+    name?: string;
+    description?: string;
+    folderId?: string | number | null;
+    environment?: string;
+    startDate?: string;
+    endDate?: string;
+  }): Promise<ZephyrTestCycle> {
+    const existing = (await this.client.get(`/testcycles/${cycleKey}`)).data;
+    const payload: Record<string, unknown> = {
+      ...existing,
+      id: existing.id,
+      key: existing.key,
+      name: data.name !== undefined ? data.name : existing.name,
+      description: data.description !== undefined ? data.description : existing.description,
+      status: existing.status,
+      project: existing.project ?? (existing.projectKey != null ? { id: existing.projectId ?? existing.projectKey } : undefined),
+      plannedStartDate: data.startDate !== undefined ? data.startDate : existing.plannedStartDate,
+      plannedEndDate: data.endDate !== undefined ? data.endDate : existing.plannedEndDate,
+    };
+    if (data.environment !== undefined) payload.environment = data.environment;
+    if (data.folderId !== undefined) payload.folderId = data.folderId;
+    const response = await this.client.put(`/testcycles/${cycleKey}`, payload);
     return response.data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 
 import { readJiraIssue } from './tools/jira-issues.js';
 import { createTestPlan, listTestPlans } from './tools/test-plans.js';
-import { createTestCycle, listTestCycles, addTestCasesToCycle } from './tools/test-cycles.js';
+import { createTestCycle, listTestCycles, addTestCasesToCycle, updateTestCycle } from './tools/test-cycles.js';
 import {
   createTestExecution,
   executeTest,
@@ -26,6 +26,7 @@ import {
   listTestPlansSchema,
   createTestCycleSchema,
   listTestCyclesSchema,
+  updateTestCycleSchema,
   executeTestSchema,
   getTestExecutionStatusSchema,
   listTestExecutionsInCycleSchema,
@@ -45,6 +46,7 @@ import {
   ListTestPlansInput,
   CreateTestCycleInput,
   ListTestCyclesInput,
+  UpdateTestCycleInput,
   ExecuteTestInput,
   GetTestExecutionStatusInput,
   ListTestExecutionsInCycleInput,
@@ -126,11 +128,29 @@ const TOOLS = [
         description: { type: 'string', description: 'Test cycle description (optional)' },
         projectKey: { type: 'string', description: 'JIRA project key' },
         versionId: { type: 'string', description: 'JIRA version ID' },
+        folderId: { type: 'string', description: 'Folder ID (TEST_CYCLE) to place the cycle in (optional)' },
         environment: { type: 'string', description: 'Test environment (optional)' },
         startDate: { type: 'string', description: 'Planned start date (ISO format, optional)' },
         endDate: { type: 'string', description: 'Planned end date (ISO format, optional)' },
       },
       required: ['name', 'projectKey', 'versionId'],
+    },
+  },
+  {
+    name: 'update_test_cycle',
+    description: 'Update a test cycle (e.g. name, description, folderId, dates)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cycleKey: { type: 'string', description: 'Test cycle key (e.g. CP-R32)' },
+        name: { type: 'string', description: 'New name (optional)' },
+        description: { type: 'string', description: 'New description (optional)' },
+        folderId: { type: 'string', description: 'Move to this folder ID (optional)' },
+        environment: { type: 'string', description: 'Environment (optional)' },
+        startDate: { type: 'string', description: 'Planned start date ISO (optional)' },
+        endDate: { type: 'string', description: 'Planned end date ISO (optional)' },
+      },
+      required: ['cycleKey'],
     },
   },
   {
@@ -494,6 +514,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await createTestCycle(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_test_cycle': {
+        const validatedArgs = validateInput<UpdateTestCycleInput>(updateTestCycleSchema, args, 'update_test_cycle');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await updateTestCycle(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-cycles.ts
+++ b/src/tools/test-cycles.ts
@@ -3,9 +3,11 @@ import {
   createTestCycleSchema,
   listTestCyclesSchema,
   addTestCasesToCycleSchema,
+  updateTestCycleSchema,
   CreateTestCycleInput,
   ListTestCyclesInput,
   AddTestCasesToCycleInput,
+  UpdateTestCycleInput,
 } from '../utils/validation.js';
 
 let zephyrClient: ZephyrClient | null = null;
@@ -26,6 +28,7 @@ export const createTestCycle = async (input: CreateTestCycleInput) => {
       description: validatedInput.description,
       projectKey: validatedInput.projectKey,
       versionId: validatedInput.versionId,
+      folderId: validatedInput.folderId,
       environment: validatedInput.environment,
       startDate: validatedInput.startDate,
       endDate: validatedInput.endDate,
@@ -46,6 +49,37 @@ export const createTestCycle = async (input: CreateTestCycleInput) => {
         plannedEndDate: testCycle.plannedEndDate,
         createdOn: testCycle.createdOn,
         executionSummary: testCycle.executionSummary,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const updateTestCycle = async (input: UpdateTestCycleInput) => {
+  const validatedInput = updateTestCycleSchema.parse(input);
+  try {
+    const testCycle = await getZephyrClient().updateTestCycle(validatedInput.cycleKey, {
+      name: validatedInput.name,
+      description: validatedInput.description,
+      folderId: validatedInput.folderId,
+      environment: validatedInput.environment,
+      startDate: validatedInput.startDate,
+      endDate: validatedInput.endDate,
+    });
+    return {
+      success: true,
+      data: {
+        id: testCycle.id,
+        key: testCycle.key,
+        name: testCycle.name,
+        description: testCycle.description,
+        status: testCycle.status,
+        plannedStartDate: testCycle.plannedStartDate,
+        plannedEndDate: testCycle.plannedEndDate,
       },
     };
   } catch (error: any) {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -13,6 +13,7 @@ export const createTestCycleSchema = z.object({
   description: z.string().optional(),
   projectKey: z.string().min(1, 'Project key is required'),
   versionId: z.string().min(1, 'Version ID is required'),
+  folderId: z.union([z.string(), z.number()]).optional(),
   environment: z.string().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
@@ -33,6 +34,16 @@ export const listTestCyclesSchema = z.object({
   projectKey: z.string().min(1, 'Project key is required'),
   versionId: z.string().optional(),
   limit: z.number().min(1).max(100).default(50),
+});
+
+export const updateTestCycleSchema = z.object({
+  cycleKey: z.string().min(1, 'Test cycle key is required'),
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  folderId: z.union([z.string(), z.number(), z.null()]).optional(),
+  environment: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
 });
 
 export const executeTestSchema = z.object({
@@ -167,6 +178,7 @@ export type CreateTestCycleInput = z.infer<typeof createTestCycleSchema>;
 export type ReadJiraIssueInput = z.infer<typeof readJiraIssueSchema>;
 export type ListTestPlansInput = z.infer<typeof listTestPlansSchema>;
 export type ListTestCyclesInput = z.infer<typeof listTestCyclesSchema>;
+export type UpdateTestCycleInput = z.infer<typeof updateTestCycleSchema>;
 export type ExecuteTestInput = z.infer<typeof executeTestSchema>;
 export type GetTestExecutionStatusInput = z.infer<typeof getTestExecutionStatusSchema>;
 export type ListTestExecutionsInCycleInput = z.infer<typeof listTestExecutionsInCycleSchema>;


### PR DESCRIPTION
## Summary

Adds folder support for test cycles and a new **update_test_cycle** tool so cycles can be created in a folder and later moved or updated.

## Changes

- **create_test_cycle** — Optional `folderId` (TEST_CYCLE folder). Create cycles in a specific folder (e.g. "Onboard release", "Regressions").
- **update_test_cycle** — New tool. Updates a cycle (e.g. `folderId`, name, description, environment, startDate, endDate). The Zephyr API requires a full body for PUT, so the client GETs the cycle first and merges the requested changes before PUT.

## Testing

- Created CP-R33 in folder "Onboard release" (335328).
- Updated CP-R33 to folder "Regressions" (335327) via update_test_cycle after fixing PUT to send full body.