### PR TITLE
fix: send priority and status as { id } on create test case (v0.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ create_folder({ projectKey: "ABC", name: "Subfolder", parentId: 12345 });
 ```ts
 list_priorities({ projectKey: "ABC" });   // or omit projectKey for all
 list_statuses({ projectKey: "ABC" });     // use returned id in create_test_case / update_test_case
+create_test_case({ projectKey: "ABC", name: "...", priority: "365033" });  // priority/status sent as { id } to API
 ```
 
 **Test cases**

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -62,7 +62,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 ### 8. **Priorities and statuses (lookups)**
 
 - **API:** `GET /priorities`, `GET /statuses` (optional projectKey).
-- **MCP status:** Implemented (`list_priorities`, `list_statuses`). Returns id and name for each; use these ids when creating or updating test cases (priority, status fields).
+- **MCP status:** Implemented (`list_priorities`, `list_statuses`). Returns id and name for each; use these ids when creating or updating test cases (priority, status fields). Create test case sends priority/status as `{ id: <id> }` so the API accepts them (v0.6.1).
 
 ### 9. **Environments**
 

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -369,11 +369,15 @@ export class ZephyrClient {
     };
 
     if (data.priority) {
-      payload.priority = data.priority;
+      payload.priority = typeof data.priority === 'object' && data.priority !== null && 'id' in data.priority
+        ? data.priority
+        : { id: Number(data.priority) || data.priority };
     }
 
     if (data.status) {
-      payload.status = data.status;
+      payload.status = typeof data.status === 'object' && data.status !== null && 'id' in data.status
+        ? data.status
+        : { id: Number(data.status) || data.status };
     }
 
     if (data.folderId) {


### PR DESCRIPTION
**Bugfix v0.6.1**

Zephyr API expects `priority` and `status` as objects with `id`, not raw number/string. `update_test_case` already sent `{ id: ... }`; `create_test_case` was sending the raw value, so created cases showed default (Normal) priority.

- **Change:** In `createTestCase`, when `priority` or `status` are set, send them as `{ id: <id> }` (same as update path).
- **Docs:** README priorities/statuses example + gaps doc note.

Tag: **v0.6.1**