### PR TITLE
feat: Test script types (step-by-step, plain text, BDD) — v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **list_test_executions_in_cycle** | List test cases and executions in a cycle. |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
-| **create_test_case** / **search_test_cases** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, get, update (including custom fields), bulk create. |
+| **create_test_case** / **search_test_cases** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
+| **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
 | **execute_test** | Update test execution status (PASS/FAIL/WIP/BLOCKED). |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
 | **link_tests_to_issues** | Link test cases to JIRA issues. |
@@ -152,13 +153,23 @@ list_statuses({ projectKey: "ABC" });     // use returned id in create_test_case
 create_test_case({ projectKey: "ABC", name: "...", priority: "365033" });  // priority/status sent as { id } to API
 ```
 
-**Test cases**
+**Test cases and script types**
 ```ts
 create_test_case({ projectKey: "ABC", name: "Login test", objective: "...", testScript: { type: "STEP_BY_STEP", steps: [...] }, customFields: { "Execution": "Manual" } });
+create_test_case({ projectKey: "ABC", name: "Free text test", testScript: { type: "PLAIN_TEXT", text: "Manual instructions here." } });
+create_test_case({ projectKey: "ABC", name: "BDD scenario", testScript: { type: "CUCUMBER", text: "Given ... When ... Then ..." });  // CUCUMBER if supported by instance
 search_test_cases({ projectKey: "ABC", query: "login", limit: 20 });
 get_test_case({ testCaseId: "ABC-T123" });
 update_test_case({ testCaseId: "ABC-T123", customFields: { "Created On": "2026-03-11" } });
 create_multiple_test_cases({ testCases: [...], continueOnError: true });
+```
+
+**Test steps (step-by-step test cases)**
+```ts
+list_test_steps({ testCaseKey: "ABC-T123" });
+create_test_step({ testCaseKey: "ABC-T123", description: "Click Login", expectedResult: "Form submits", testData: "user@example.com" });
+update_test_step({ testCaseKey: "ABC-T123", stepId: 1, expectedResult: "Redirect to dashboard" });
+delete_test_step({ testCaseKey: "ABC-T123", stepId: 2 });
 ```
 
 **Execution and reporting**
@@ -229,10 +240,9 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Folders** — `list_folders` and `create_folder` (filter by folderType, parentId for hierarchy).
 - [x] **Priorities and statuses** — `list_priorities` and `list_statuses` (id and name for create/update test case).
 - [ ] **Zephyr projects list** — List projects from Zephyr API for projectKey discovery.
-- [ ] **Priorities and statuses** — List valid priority/status values for test cases.
 - [ ] **Environments** — List or manage environments for cycles.
 - [ ] **Test case archive / delete** — Archive and delete test cases (per Zephyr docs).
-- [ ] **Test steps as separate resource** — If the API supports it: list/edit/delete steps for a test case independently.
+- [x] **Test steps as separate resource** — `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` (v0.7). Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER.
 - [ ] **Remove test case from cycle** — Remove a test from a cycle (if supported by API).
 - [ ] **Update test plan / test cycle** — PUT for plans and cycles (rename, dates, status).
 - [ ] **Bulk operations** — Bulk execution updates or bulk add-to-cycle (beyond `create_multiple_test_cases`).

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -77,8 +77,16 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 11. **Test steps as a separate resource**
 
-- **API:** If the Cloud v2 API exposes e.g. `GET/POST/PUT/DELETE /testcases/{key}/teststeps` for managing steps independently.
-- **Gap:** Steps are only supported inline in create/update test case (`testScript.steps`). No dedicated “list/edit/delete steps” for an existing test case if the API supports it.
+- **API:** Cloud v2 exposes `GET/POST/PUT/DELETE /testcases/{key}/teststeps` for managing steps independently.
+- **MCP status:** Implemented (v0.7). `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step`. Steps are normalized (description, expectedResult, testData) regardless of API field names (step/data/result). Test script types supported in create/update test case: **STEP_BY_STEP** (default when steps provided), **PLAIN_TEXT** (free text), **CUCUMBER** (BDD/Gherkin; support may vary by instance).
+
+### 11b. **Setting test script type to BDD (Gherkin) via public API**
+
+- **Observed behaviour:** Plain text works via Scale API `PUT /testcases/{key}/testscript` with `{ plainScript: { text } }`. The same endpoint accepts `{ bddScript: { text } }` (no error) but the test case remains **Step-by-step** in the UI; the script type is not changed.
+- **UI behaviour:** When switching to BDD in the Zephyr UI, the browser calls **TM4J app backend** `PUT https://eu.app.tm4j.smartbear.com/backend/rest/tests/2.0/testcase/{id}` with body `{ id, projectId, testScript: { bddScript: { text } } }`. That backend is not the public Scale API; calling it with the same Bearer token returns **404 Tenant could not be found** (tenant likely resolved from session/cookies in the browser).
+- **What users report:** Community threads ([Create test script](https://community.smartbear.com/discussions/zephyrscale/api-documentation-for-create-test-script/215537), [Step-by-step vs Plain text](https://community.smartbear.com/discussions/zephyrscale/does-zephyr-support-both-test-script-types-step-by-step-and-plain-text-for-same-/219729)) describe the **Create test script** endpoint with a `type` parameter (e.g. `"steps"`); examples for multiple steps or non-steps types are limited. No clear success stories for setting BDD via the **public** Scale API only.
+- **Other product (Zephyr Squad Cloud):** The [BDD Content API](https://zephyr-squad-cloud-v1.sb-docs.com/en/zephyr-squad-cloud-rest-api/bdd-content-api) uses a different base URL (`prod-api.zephyr4jiracloud.com`), works with issues that have labels `BDD_Feature` / `BDD_Scenario`, and uses Jira issue ID (not test case key). That is a different product/API from Zephyr Scale.
+- **Conclusion / workaround:** With the **public Zephyr Scale API** (api.zephyrscale.smartbear.com) we can create test cases and set **plain text** script; **BDD** type appears to be applied only via the **TM4J app backend**, which is not reliably callable with the same API token (tenant/404). Workaround: create the test case via API, then set script type to BDD and paste Gherkin content **manually in the UI**, or use a different integration (e.g. Atlassian Connect–style endpoint or session-based auth) if available.
 
 ### 12. **Remove test case from cycle**
 
@@ -111,10 +119,32 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 8 | List priorities/statuses | GET priorities, statuses | Implemented |
 | 9 | List/manage environments | GET (environments) | Not implemented |
 | 10 | Archive/delete test case | Archive + delete (per docs) | Not implemented |
-| 11 | Test steps CRUD (if separate) | testcases/{key}/teststeps | Not implemented |
+| 11 | Test steps CRUD | testcases/{key}/teststeps | Implemented (v0.7) |
 | 12 | Remove test case from cycle | DELETE (if exists) | Not implemented |
 | 13 | Update test plan / test cycle | PUT testplans, testcycles | Not implemented |
 | 14 | Bulk operations (executions, cycle) | Bulk endpoints (if any) | Not implemented |
+
+---
+
+## Known issues (with evidence)
+
+These are limitations or bugs we have confirmed and for which we have references (community threads, API behaviour).
+
+### BDD script type cannot be set via the public Scale API
+
+- **Conclusion:** The public Zephyr Scale API does not switch a test case’s script type to BDD. Sending `PUT /testcases/{key}/testscript` with `{ bddScript: { text } }` is accepted (no error) but the UI stays Step-by-step. The UI uses the **TM4J app backend** (`eu.app.tm4j.smartbear.com/backend/rest/tests/2.0/testcase/{id}`) to set BDD; calling that backend with the same Bearer token returns **404 Tenant could not be found**.
+- **References:**
+  - [API Documentation for Create test script](https://community.smartbear.com/discussions/zephyrscale/api-documentation-for-create-test-script/215537) — describes Create test script with limited examples for script types.
+  - [Step-by-step vs Plain text (same test case)](https://community.smartbear.com/discussions/zephyrscale/does-zephyr-support-both-test-script-types-step-by-step-and-plain-text-for-same-/219729) — discussion of script types; no clear success for BDD via public API only.
+- **Documentation:** The official API docs do not describe how to create or set BDD script type via the API; BDD is documented only in the UI (Test Script tab → Type dropdown → BDD - Gherkin). So BDD via API is **underdocumented** at best.
+- **Tried:** On create: `testScript: { type: 'bdd' }` and `type: 'bddScript'`; after create: PUT with `bddScript: { text }`, and PUT with `{ type: 'bdd' | 'bddScript', bddScript: { text } }` or `{ type, text }`. All accepted; UI still shows Step-by-step. Plain text and step-by-step work via the same API. **Conclusion: likely a product bug or undocumented limitation** (only BDD cannot be set via the public API).
+- **Workaround:** Create the test case via API, then set script type to BDD and paste Gherkin in the UI; or use an integration that can call the TM4J app backend with session/tenant context.
+
+### Step-by-step: bulk “createTestCaseTestSteps” fails; add steps one-by-one
+
+- **Observed:** When creating a test case with step-by-step script, a post-create call to add steps using the documented bulk shape fails. Sending `POST /testcases/{key}/teststeps` with `{ mode: "APPEND", items: [ { inline: { description, testData, expectedResult }, testCase: { testCaseKey, self } } ] }` returns **400** with message like **`createTestCaseTestSteps: must not be null`** (US) or **`createTestCaseTestSteps.mode: must not be null`** (EU). Wrapping in `{ createTestCaseTestSteps: { mode, items } }` does not resolve it on EU.
+- **Community evidence:** [Test to write to Zephyr Scale – createTestCaseTestSteps: must not be null](https://community.smartbear.com/discussions/zephyrscale/test-to-write-to-zphyr-scales--errorcode400messagecreatetestcaseteststeps-must-n/235621) — same payload and same error (bulk with `mode` and `items`).
+- **Workaround:** Add steps **one at a time** with a **flat** body per step: `POST /testcases/{key}/teststeps` with `{ description, expectedResult, testData }` (or `step` / `result` / `data`). The MCP server uses this single-step contract for `create_test_step` and for the step-by-step fallback after create.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsup src/index.ts src/scripts/test-create-execution.ts src/scripts/test-priorities-statuses.ts --format esm --dts && echo '#!/usr/bin/env node' | cat - dist/index.js > temp && mv temp dist/index.js && chmod +x dist/index.js",
+    "build": "tsup src/index.ts src/scripts/test-create-execution.ts src/scripts/test-priorities-statuses.ts src/scripts/test-100-steps.ts --format esm --dts && echo '#!/usr/bin/env node' | cat - dist/index.js > temp && mv temp dist/index.js && chmod +x dist/index.js",
     "dev": "tsup src/index.ts --format esm --dts --watch",
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -10,6 +10,7 @@ import {
   ZephyrFolder,
   ZephyrPriority,
   ZephyrStatus,
+  ZephyrTestStep,
 } from '../types/zephyr-types.js';
 
 export class ZephyrClient {
@@ -320,6 +321,89 @@ export class ZephyrClient {
     return response.data;
   }
 
+  /**
+   * Fetch test script details (type, text) for a test case. GET /testcases/{key} only returns testScript.self.
+   */
+  async getTestScript(testCaseKey: string): Promise<{ type?: string; text?: string; [k: string]: any } | null> {
+    try {
+      const response = await this.client.get(`/testcases/${testCaseKey}/testscript`);
+      return response.data ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Normalize step from API (step/data/result or description/expectedResult/testData) to unified shape. */
+  private normalizeStep(raw: Record<string, any>): ZephyrTestStep {
+    return {
+      id: raw.id,
+      orderId: raw.orderId ?? raw.index,
+      index: raw.orderId ?? raw.index,
+      description: raw.description ?? raw.step ?? '',
+      step: raw.step ?? raw.description,
+      testData: raw.testData ?? raw.data,
+      data: raw.data ?? raw.testData,
+      expectedResult: raw.expectedResult ?? raw.result ?? '',
+      result: raw.result ?? raw.expectedResult,
+    };
+  }
+
+  async getTestSteps(testCaseKey: string): Promise<ZephyrTestStep[]> {
+    const response = await this.client.get(`/testcases/${testCaseKey}/teststeps`);
+    const rawSteps = response.data?.values ?? response.data ?? [];
+    const list = Array.isArray(rawSteps) ? rawSteps : [];
+    return list.map((s: Record<string, any>) => this.normalizeStep(s));
+  }
+
+  async createTestStep(testCaseKey: string, step: {
+    description: string;
+    expectedResult: string;
+    testData?: string;
+    index?: number;
+  }): Promise<ZephyrTestStep> {
+    const body: Record<string, any> = {
+      description: step.description,
+      expectedResult: step.expectedResult,
+      step: step.description,
+      result: step.expectedResult,
+    };
+    if (step.testData !== undefined && step.testData !== '') {
+      body.testData = step.testData;
+      body.data = step.testData;
+    }
+    if (step.index != null) body.index = step.index;
+    const response = await this.client.post(`/testcases/${testCaseKey}/teststeps`, body);
+    return this.normalizeStep(response.data ?? {});
+  }
+
+  async updateTestStep(testCaseKey: string, stepId: number, step: {
+    description?: string;
+    expectedResult?: string;
+    testData?: string;
+    index?: number;
+  }): Promise<ZephyrTestStep> {
+    const body: Record<string, any> = {};
+    if (step.description !== undefined) {
+      body.description = step.description;
+      body.step = step.description;
+    }
+    if (step.expectedResult !== undefined) {
+      body.expectedResult = step.expectedResult;
+      body.result = step.expectedResult;
+    }
+    if (step.testData !== undefined) {
+      body.testData = step.testData;
+      body.data = step.testData;
+    }
+    if (step.index !== undefined) body.index = step.index;
+    const response = await this.client.put(`/testcases/${testCaseKey}/teststeps/${stepId}`, body);
+    return this.normalizeStep(response.data ?? {});
+  }
+
+  async deleteTestStep(testCaseKey: string, stepId: number): Promise<void> {
+    await this.client.delete(`/testcases/${testCaseKey}/teststeps/${stepId}`);
+  }
+
   async searchTestCases(projectKey: string, query?: string, limit = 50): Promise<{
     testCases: ZephyrTestCase[];
     total: number;
@@ -350,7 +434,7 @@ export class ZephyrClient {
     componentId?: string;
     customFields?: Record<string, any>;
     testScript?: {
-      type: 'STEP_BY_STEP' | 'PLAIN_TEXT';
+      type?: 'STEP_BY_STEP' | 'PLAIN_TEXT' | 'CUCUMBER';
       steps?: Array<{
         index: number;
         description: string;
@@ -396,12 +480,154 @@ export class ZephyrClient {
       payload.customFields = data.customFields;
     }
 
-    if (data.testScript) {
-      payload.testScript = data.testScript;
+    const script = data.testScript;
+    const isPlainOrCucumber = script && (script.type === 'PLAIN_TEXT' || script.type === 'CUCUMBER') && script.text;
+    if (isPlainOrCucumber) {
+      const apiType = script!.type === 'PLAIN_TEXT' ? 'plain' : 'bdd';
+      payload.testScript = { type: apiType, text: script!.text };
     }
 
     const response = await this.client.post('/testcases', payload);
-    return response.data;
+    const created = response.data;
+    if (script && created?.key) {
+      await this._applyTestScriptAfterCreate(created, script);
+    }
+    return created;
+  }
+
+  /**
+   * Apply test script after create. Cloud API often ignores inline testScript on POST /testcases.
+   * BDD script type cannot be set via public API (see docs Known issues).
+   */
+  private async _applyTestScriptAfterCreate(created: ZephyrTestCase | { key: string; id?: number; project?: { id: number }; projectId?: number }, script: {
+    type?: 'STEP_BY_STEP' | 'PLAIN_TEXT' | 'CUCUMBER';
+    steps?: Array<{ index: number; description: string; testData?: string; expectedResult: string }>;
+    text?: string;
+  }): Promise<void> {
+    const testCaseKey = created.key;
+    const baseUrl = (this.client.defaults.baseURL ?? '').replace(/\/$/, '');
+    const scriptType = script.type ?? (script.steps?.length ? 'STEP_BY_STEP' : 'PLAIN_TEXT');
+
+    if ((scriptType === 'PLAIN_TEXT' || scriptType === 'CUCUMBER') && script.text) {
+      const path = `/testcases/${testCaseKey}/testscript`;
+      const payload = scriptType === 'PLAIN_TEXT'
+        ? { plainScript: { text: script.text } }
+        : { bddScript: { text: script.text } };
+      let done = false;
+
+      const existing = await this.getTestScript(testCaseKey).catch(() => null);
+      if (existing && typeof existing === 'object') {
+        const key = scriptType === 'PLAIN_TEXT' ? 'plainScript' : 'bddScript';
+        const existingBlock = (existing as any)[key];
+        const putBody = existingBlock
+          ? { ...(existing as object), [key]: { ...(existingBlock as object), text: script.text } }
+          : payload;
+        try {
+          await this.client.put(path, putBody);
+          done = true;
+        } catch {
+          // continue to fallbacks
+        }
+      }
+      if (!done) {
+        try {
+          await this.client.put(path, payload);
+          done = true;
+        } catch {
+          // continue
+        }
+      }
+      if (!done) {
+        try {
+          await this.client.post(path, payload);
+          done = true;
+        } catch {
+          // continue
+        }
+      }
+      if (!done && scriptType === 'PLAIN_TEXT') {
+        const alt = { type: 'plain', text: script.text };
+        try {
+          await this.client.put(path, alt);
+          done = true;
+        } catch {
+          try {
+            await this.client.post(path, alt);
+            done = true;
+          } catch {
+            // ignore
+          }
+        }
+      }
+      if (!done && scriptType === 'CUCUMBER') {
+        for (const typeVal of ['bdd', 'bddScript']) {
+          try {
+            await this.client.put(path, { type: typeVal, bddScript: { text: script.text } });
+            done = true;
+            break;
+          } catch {
+            try {
+              await this.client.put(path, { type: typeVal, text: script.text });
+              done = true;
+              break;
+            } catch {
+              // continue
+            }
+          }
+        }
+      }
+      return;
+    }
+
+    if (scriptType === 'STEP_BY_STEP' && script.steps?.length) {
+      const steps = script.steps.sort((a, b) => a.index - b.index);
+      const selfUrl = `${baseUrl}/testcases/${testCaseKey}/teststeps`;
+      for (const s of steps) {
+        await this._addOneTestStep(testCaseKey, selfUrl, s);
+      }
+    }
+  }
+
+  /**
+   * Add a single step. Tries flat body first (createTestStep); if API returns createTestCaseTestSteps error, retries with bulk wrapper (one item).
+   */
+  private async _addOneTestStep(
+    testCaseKey: string,
+    selfUrl: string,
+    s: { index: number; description: string; testData?: string; expectedResult: string },
+  ): Promise<void> {
+    try {
+      await this.createTestStep(testCaseKey, {
+        description: s.description,
+        expectedResult: s.expectedResult,
+        testData: s.testData ?? '',
+        index: s.index,
+      });
+    } catch (err: any) {
+      const msg = err.response?.data?.message ?? err.message ?? '';
+      if (err.response?.status !== 400 || !String(msg).includes('createTestCaseTestSteps')) {
+        throw err;
+      }
+      // Inline step only: do not send testCase in item (API: "inline or call to test, not both").
+      const oneItem = {
+        inline: {
+          description: s.description,
+          testData: s.testData ?? '',
+          expectedResult: s.expectedResult,
+          customFields: null,
+        },
+      };
+      try {
+        await this.client.post(`/testcases/${testCaseKey}/teststeps`, {
+          createTestCaseTestSteps: { mode: 'APPEND', items: [oneItem] },
+        });
+      } catch {
+        await this.client.post(`/testcases/${testCaseKey}/teststeps`, {
+          mode: 'APPEND',
+          items: [oneItem],
+        });
+      }
+    }
   }
 
   async updateTestCase(testCaseKey: string, data: {
@@ -416,7 +642,7 @@ export class ZephyrClient {
     componentId?: string;
     customFields?: Record<string, any>;
     testScript?: {
-      type: 'STEP_BY_STEP' | 'PLAIN_TEXT';
+      type?: 'STEP_BY_STEP' | 'PLAIN_TEXT' | 'CUCUMBER';
       steps?: Array<{
         index: number;
         description: string;
@@ -467,7 +693,7 @@ export class ZephyrClient {
     componentId?: string;
     customFields?: Record<string, any>;
     testScript?: {
-      type: 'STEP_BY_STEP' | 'PLAIN_TEXT';
+      type?: 'STEP_BY_STEP' | 'PLAIN_TEXT' | 'CUCUMBER';
       steps?: Array<{
         index: number;
         description: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   generateTestReport,
 } from './tools/test-execution.js';
 import { createTestCase, searchTestCases, getTestCase, updateTestCase, createMultipleTestCases } from './tools/test-cases.js';
+import { listTestSteps, createTestStep, updateTestStep, deleteTestStep } from './tools/test-steps.js';
 import { listFolders, createFolder } from './tools/folders.js';
 import { listPriorities, listStatuses } from './tools/priorities-statuses.js';
 import {
@@ -44,6 +45,10 @@ import {
   getTestCaseSchema,
   updateTestCaseSchema,
   createMultipleTestCasesSchema,
+  listTestStepsSchema,
+  createTestStepSchema,
+  updateTestStepSchema,
+  deleteTestStepSchema,
   ReadJiraIssueInput,
   CreateTestPlanInput,
   ListTestPlansInput,
@@ -66,6 +71,10 @@ import {
   GetTestCaseInput,
   UpdateTestCaseInput,
   CreateMultipleTestCasesInput,
+  ListTestStepsInput,
+  CreateTestStepInput,
+  UpdateTestStepInput,
+  DeleteTestStepInput,
 } from './utils/validation.js';
 
 const server = new Server(
@@ -326,9 +335,9 @@ const TOOLS = [
         customFields: { type: 'object', description: 'Custom fields as key-value pairs (optional)' },
         testScript: {
           type: 'object',
-          description: 'Test script with steps (optional)',
+          description: 'Test script (optional). type: STEP_BY_STEP (default when steps provided), PLAIN_TEXT, or CUCUMBER.',
           properties: {
-            type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT'], description: 'Script type' },
+            type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT', 'CUCUMBER'], description: 'Script type (default STEP_BY_STEP for steps, PLAIN_TEXT for free text)' },
             steps: {
               type: 'array',
               items: {
@@ -343,12 +352,65 @@ const TOOLS = [
               },
               description: 'Test steps (for STEP_BY_STEP type)',
             },
-            text: { type: 'string', description: 'Plain text script (for PLAIN_TEXT type)' },
+            text: { type: 'string', description: 'Plain text or Cucumber script (for PLAIN_TEXT/CUCUMBER type)' },
           },
-          required: ['type'],
         },
       },
       required: ['projectKey', 'name'],
+    },
+  },
+  {
+    name: 'list_test_steps',
+    description: 'List test steps for a test case (step-by-step script). Use test case key (e.g. CP-T123).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key (e.g. CP-T123)' },
+      },
+      required: ['testCaseKey'],
+    },
+  },
+  {
+    name: 'create_test_step',
+    description: 'Add a test step to an existing test case. Use for step-by-step test cases.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key' },
+        description: { type: 'string', description: 'Step description/action' },
+        expectedResult: { type: 'string', description: 'Expected result' },
+        testData: { type: 'string', description: 'Test data (optional)' },
+        index: { type: 'number', description: 'Step order (optional)' },
+      },
+      required: ['testCaseKey', 'description', 'expectedResult'],
+    },
+  },
+  {
+    name: 'update_test_step',
+    description: 'Update an existing test step (description, expectedResult, testData, or index).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key' },
+        stepId: { type: 'number', description: 'Step ID (from list_test_steps)' },
+        description: { type: 'string', description: 'New step description (optional)' },
+        expectedResult: { type: 'string', description: 'New expected result (optional)' },
+        testData: { type: 'string', description: 'New test data (optional)' },
+        index: { type: 'number', description: 'New step order (optional)' },
+      },
+      required: ['testCaseKey', 'stepId'],
+    },
+  },
+  {
+    name: 'delete_test_step',
+    description: 'Delete a test step from a test case.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key' },
+        stepId: { type: 'number', description: 'Step ID (from list_test_steps)' },
+      },
+      required: ['testCaseKey', 'stepId'],
     },
   },
   {
@@ -396,7 +458,7 @@ const TOOLS = [
           type: 'object',
           description: 'Test script (optional)',
           properties: {
-            type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT'] },
+            type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT', 'CUCUMBER'] },
             steps: {
               type: 'array',
               items: {
@@ -412,7 +474,6 @@ const TOOLS = [
             },
             text: { type: 'string' },
           },
-          required: ['type'],
         },
       },
       required: ['testCaseId'],
@@ -444,7 +505,7 @@ const TOOLS = [
                 type: 'object',
                 description: 'Test script with steps (optional)',
                 properties: {
-                  type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT'], description: 'Script type' },
+                  type: { type: 'string', enum: ['STEP_BY_STEP', 'PLAIN_TEXT', 'CUCUMBER'], description: 'Script type' },
                   steps: {
                     type: 'array',
                     items: {
@@ -755,6 +816,54 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await createMultipleTestCases(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_test_steps': {
+        const validatedArgs = validateInput<ListTestStepsInput>(listTestStepsSchema, args, 'list_test_steps');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await listTestSteps(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'create_test_step': {
+        const validatedArgs = validateInput<CreateTestStepInput>(createTestStepSchema, args, 'create_test_step');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await createTestStep(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_test_step': {
+        const validatedArgs = validateInput<UpdateTestStepInput>(updateTestStepSchema, args, 'update_test_step');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await updateTestStep(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'delete_test_step': {
+        const validatedArgs = validateInput<DeleteTestStepInput>(deleteTestStepSchema, args, 'delete_test_step');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await deleteTestStep(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/scripts/test-100-steps.ts
+++ b/src/scripts/test-100-steps.ts
@@ -1,0 +1,44 @@
+/**
+ * One-off test: create a step-by-step test case with 100 steps and a plain-text
+ * test case with the same 100 steps as text. Run from repo root with env set
+ * (ZEPHYR_API_TOKEN, ZEPHYR_BASE_URL or ZEPHYR_API_BASE_URL, JIRA_*).
+ *
+ * Usage: node dist/scripts/test-100-steps.js [path-to-payloads.json]
+ * Requires env: JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN, ZEPHYR_API_TOKEN (and ZEPHYR_API_BASE_URL for EU).
+ * Generate payloads with: node -e "const steps=[...]; const plain=...; require('fs').writeFileSync('payloads.json', JSON.stringify({stepByStep:{projectKey:'CP',name:'Step-by-step 100 steps',testScript:{type:'STEP_BY_STEP',steps}}, plainText:{projectKey:'CP',name:'Plain text 100 steps',testScript:{type:'PLAIN_TEXT',text:plain}}}));"
+ */
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { ZephyrClient } from '../clients/zephyr-client.js';
+
+async function main() {
+  const payloadPath =
+    process.argv[2] ||
+    resolve(process.cwd(), 'tmp-zephyr-100steps.json');
+  const raw = await readFile(payloadPath, 'utf8');
+  const { stepByStep, plainText } = JSON.parse(raw);
+
+  const client = new ZephyrClient();
+
+  console.log('Creating step-by-step test case (100 steps)...');
+  try {
+    const createdSteps = await client.createTestCase(stepByStep);
+    console.log('Step-by-step:', createdSteps.key, createdSteps.id);
+  } catch (err: any) {
+    console.error('Step-by-step error:', err.response?.data?.message ?? err.message);
+    process.exit(1);
+  }
+
+  console.log('Creating plain-text test case (same 100 steps as text)...');
+  try {
+    const createdPlain = await client.createTestCase(plainText);
+    console.log('Plain text:', createdPlain.key, createdPlain.id);
+  } catch (err: any) {
+    console.error('Plain-text error:', err.response?.data?.message ?? err.message);
+    process.exit(1);
+  }
+
+  console.log('Done.');
+}
+
+main();

--- a/src/tools/test-cases.ts
+++ b/src/tools/test-cases.ts
@@ -114,7 +114,13 @@ export const searchTestCases = async (input: SearchTestCasesInput) => {
 export const getTestCase = async (input: { testCaseId: string }) => {
   try {
     const testCase = await getZephyrClient().getTestCase(input.testCaseId);
-    
+    let testScript = testCase.testScript as Record<string, unknown> | undefined;
+    if (testCase.key && testScript?.self) {
+      const scriptDetails = await getZephyrClient().getTestScript(testCase.key);
+      if (scriptDetails && typeof scriptDetails === 'object') {
+        testScript = { ...testScript, ...scriptDetails };
+      }
+    }
     return {
       success: true,
       data: {
@@ -134,7 +140,7 @@ export const getTestCase = async (input: { testCaseId: string }) => {
         createdOn: testCase.createdOn,
         customFields: testCase.customFields,
         links: testCase.links,
-        testScript: testCase.testScript,
+        testScript,
       },
     };
   } catch (error: any) {

--- a/src/tools/test-steps.ts
+++ b/src/tools/test-steps.ts
@@ -1,0 +1,119 @@
+import { ZephyrClient } from '../clients/zephyr-client.js';
+import {
+  listTestStepsSchema,
+  createTestStepSchema,
+  updateTestStepSchema,
+  deleteTestStepSchema,
+  ListTestStepsInput,
+  CreateTestStepInput,
+  UpdateTestStepInput,
+  DeleteTestStepInput,
+} from '../utils/validation.js';
+
+let zephyrClient: ZephyrClient | null = null;
+
+const getZephyrClient = (): ZephyrClient => {
+  if (!zephyrClient) {
+    zephyrClient = new ZephyrClient();
+  }
+  return zephyrClient;
+};
+
+export const listTestSteps = async (input: ListTestStepsInput) => {
+  const validated = listTestStepsSchema.parse(input);
+  try {
+    const steps = await getZephyrClient().getTestSteps(validated.testCaseKey);
+    return {
+      success: true,
+      data: {
+        testCaseKey: validated.testCaseKey,
+        steps: steps.map(s => ({
+          id: s.id,
+          index: s.index ?? s.orderId,
+          description: s.description ?? s.step,
+          testData: s.testData ?? s.data,
+          expectedResult: s.expectedResult ?? s.result,
+        })),
+        total: steps.length,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message ?? error.message,
+    };
+  }
+};
+
+export const createTestStep = async (input: CreateTestStepInput) => {
+  const validated = createTestStepSchema.parse(input);
+  try {
+    const step = await getZephyrClient().createTestStep(validated.testCaseKey, {
+      description: validated.description,
+      expectedResult: validated.expectedResult,
+      testData: validated.testData,
+      index: validated.index,
+    });
+    return {
+      success: true,
+      data: {
+        testCaseKey: validated.testCaseKey,
+        step: {
+          id: step.id,
+          index: step.index ?? step.orderId,
+          description: step.description ?? step.step,
+          testData: step.testData ?? step.data,
+          expectedResult: step.expectedResult ?? step.result,
+        },
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message ?? error.message,
+    };
+  }
+};
+
+export const updateTestStep = async (input: UpdateTestStepInput) => {
+  const validated = updateTestStepSchema.parse(input);
+  const { testCaseKey, stepId, ...updates } = validated;
+  try {
+    const step = await getZephyrClient().updateTestStep(testCaseKey, stepId, updates);
+    return {
+      success: true,
+      data: {
+        testCaseKey,
+        stepId,
+        step: {
+          id: step.id,
+          index: step.index ?? step.orderId,
+          description: step.description ?? step.step,
+          testData: step.testData ?? step.data,
+          expectedResult: step.expectedResult ?? step.result,
+        },
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message ?? error.message,
+    };
+  }
+};
+
+export const deleteTestStep = async (input: DeleteTestStepInput) => {
+  const validated = deleteTestStepSchema.parse(input);
+  try {
+    await getZephyrClient().deleteTestStep(validated.testCaseKey, validated.stepId);
+    return {
+      success: true,
+      data: { testCaseKey: validated.testCaseKey, stepId: validated.stepId, deleted: true },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message ?? error.message,
+    };
+  }
+};

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -147,3 +147,22 @@ export interface ZephyrTestReport {
   executions: ZephyrTestExecution[];
   generatedOn: string;
 }
+
+/** Test script type: step-by-step, plain text, or Cucumber/BDD. Default STEP_BY_STEP when steps are provided, PLAIN_TEXT for free text. */
+export type ZephyrTestScriptType = 'STEP_BY_STEP' | 'PLAIN_TEXT' | 'CUCUMBER';
+
+/** Single test step (API may use step/data/result or description/expectedResult/testData). */
+export interface ZephyrTestStep {
+  id?: number;
+  orderId?: number;
+  index?: number;
+  /** Step action/description (API field may be "step" or "description") */
+  description?: string;
+  step?: string;
+  /** Test data (API field may be "data" or "testData") */
+  testData?: string;
+  data?: string;
+  /** Expected result (API field may be "result" or "expectedResult") */
+  expectedResult?: string;
+  result?: string;
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,6 +9,7 @@ const configSchema = z.object({
   JIRA_API_TOKEN: z.string().min(1),
   ZEPHYR_API_TOKEN: z.string().min(1),
   ZEPHYR_BASE_URL: z.string().url().optional(),
+  ZEPHYR_TM4J_PROJECT_ID: z.string().optional(),
 });
 
 let cachedConfig: z.infer<typeof configSchema> | null = null;
@@ -65,4 +66,20 @@ export const getZephyrHeaders = () => {
     'Content-Type': 'application/json',
     'Authorization': `Bearer ${config.ZEPHYR_API_TOKEN}`,
   };
+};
+
+/** TM4J backend URL used to set test script type (e.g. BDD). Derive from Zephyr Scale base URL. */
+export const getTm4jBackendBaseUrl = (): string => {
+  const scaleUrl = getZephyrBaseUrl();
+  const u = new URL(scaleUrl);
+  const host = u.host.replace('api.zephyrscale.', 'app.tm4j.');
+  return `${u.protocol}//${host}/backend/rest/tests/2.0`;
+};
+
+/** Optional TM4J project id for backend PUT (set BDD script). If unset, use project.id from test case. */
+export const getTm4jProjectId = (): number | undefined => {
+  const raw = process.env.ZEPHYR_TM4J_PROJECT_ID;
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) ? n : undefined;
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -127,7 +127,7 @@ export const createTestCaseSchema = z.object({
   componentId: z.string().optional(),
   customFields: z.record(z.any()).optional(),
   testScript: z.object({
-    type: z.enum(['STEP_BY_STEP', 'PLAIN_TEXT']),
+    type: z.enum(['STEP_BY_STEP', 'PLAIN_TEXT', 'CUCUMBER']).optional(),
     steps: z.array(z.object({
       index: z.number().min(1),
       description: z.string().min(1),
@@ -161,7 +161,7 @@ export const updateTestCaseSchema = z.object({
   componentId: z.string().optional(),
   customFields: z.record(z.any()).optional(),
   testScript: z.object({
-    type: z.enum(['STEP_BY_STEP', 'PLAIN_TEXT']),
+    type: z.enum(['STEP_BY_STEP', 'PLAIN_TEXT', 'CUCUMBER']).optional(),
     steps: z.array(z.object({
       index: z.number().min(1),
       description: z.string().min(1),
@@ -183,6 +183,38 @@ export const createMultipleTestCasesSchema = z.object({
   continueOnError: z.boolean().default(true),
 });
 
+export const listTestStepsSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+});
+
+export const createTestStepSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+  description: z.string().min(1, 'Step description is required'),
+  expectedResult: z.string().min(1, 'Expected result is required'),
+  testData: z.string().optional(),
+  index: z.number().min(1).optional(),
+});
+
+export const updateTestStepSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+  stepId: z.number().int().min(1, 'Step ID is required'),
+  description: z.string().min(1).optional(),
+  expectedResult: z.string().min(1).optional(),
+  testData: z.string().optional(),
+  index: z.number().min(1).optional(),
+}).refine(
+  data => {
+    const { testCaseKey, stepId, ...updates } = data;
+    return Object.keys(updates).length >= 1;
+  },
+  { message: 'At least one field to update (description, expectedResult, testData, index) is required' }
+);
+
+export const deleteTestStepSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+  stepId: z.number().int().min(1, 'Step ID is required'),
+});
+
 export type CreateTestPlanInput = z.infer<typeof createTestPlanSchema>;
 export type CreateTestCycleInput = z.infer<typeof createTestCycleSchema>;
 export type ReadJiraIssueInput = z.infer<typeof readJiraIssueSchema>;
@@ -200,3 +232,7 @@ export type SearchTestCasesInput = z.infer<typeof searchTestCasesSchema>;
 export type GetTestCaseInput = z.infer<typeof getTestCaseSchema>;
 export type UpdateTestCaseInput = z.infer<typeof updateTestCaseSchema>;
 export type CreateMultipleTestCasesInput = z.infer<typeof createMultipleTestCasesSchema>;
+export type ListTestStepsInput = z.infer<typeof listTestStepsSchema>;
+export type CreateTestStepInput = z.infer<typeof createTestStepSchema>;
+export type UpdateTestStepInput = z.infer<typeof updateTestStepSchema>;
+export type DeleteTestStepInput = z.infer<typeof deleteTestStepSchema>;


### PR DESCRIPTION
## Summary

Implements test case script types and documents known API limitations.

- **Step-by-step:** Add steps one-by-one (flat body); fallback to single-item bulk with inline-only when API returns `createTestCaseTestSteps` error. Fixes EU "inline or call to test, not both" by omitting `testCase` from inline step items.
- **Plain text / BDD:** Apply test script after create with a clear fallback sequence (GET existing → PUT/POST, then type-specific fallbacks). BDD type still cannot be set via public API (see Known issues).
- **Docs:** BDD known issue updated with documentation gap and conclusion (likely bug or undocumented limitation). Step-by-step known issue documents bulk failure and one-by-one workaround.
- **Test steps CRUD:** `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step`.
- **Script:** `test-100-steps.ts` for local run of 100-step step-by-step and plain-text create (requires env).

**Tag:** v0.7.0