### PR TITLE
Add integration tests (mocked), contract suite; contract workflow manual only

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,35 @@
+# Zephyr integration contract tests (real API).
+# Manual only for now (workflow_dispatch). Re-enable schedule once repo secrets are set.
+# Required secrets: ZEPHYR_BASE_URL, ZEPHYR_API_TOKEN, JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN
+# Optional: ZEPHYR_CONTRACT_PROJECT_KEY, ZEPHYR_CONTRACT_PLAN_KEY, ZEPHYR_CONTRACT_CYCLE_KEY
+name: Zephyr contract
+
+on:
+  workflow_dispatch:
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Zephyr contract tests
+        env:
+          ZEPHYR_BASE_URL: ${{ secrets.ZEPHYR_BASE_URL }}
+          ZEPHYR_API_TOKEN: ${{ secrets.ZEPHYR_API_TOKEN }}
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ZEPHYR_CONTRACT_PROJECT_KEY: ${{ secrets.ZEPHYR_CONTRACT_PROJECT_KEY }}
+          ZEPHYR_CONTRACT_PLAN_KEY: ${{ secrets.ZEPHYR_CONTRACT_PLAN_KEY }}
+          ZEPHYR_CONTRACT_CYCLE_KEY: ${{ secrets.ZEPHYR_CONTRACT_CYCLE_KEY }}
+        run: npm run test:contract

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm run test
+        run: npm run test:unit
 
       - name: Typecheck
         run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An [MCP](https://modelcontextprotocol.io/) server for JIRA and **Zephyr Scale** 
 
 **Running it:** Use the published Docker image—no clone or build. Docker pulls the image when needed; you add a small config block to your AI tool (Cursor, Claude, Gemini, Windsurf, etc.). Cloning and building from source is for **developers and contributors** only.
 
+[![Zephyr contract](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml) — Zephyr API contract tests (daily / on demand).
+
 ---
 
 ## Why this fork?

--- a/docs/FIXTURE-SANITIZATION.md
+++ b/docs/FIXTURE-SANITIZATION.md
@@ -1,0 +1,45 @@
+# Fixture sanitization rules
+
+Fixtures under `tests/fixtures/` are used in **unit tests** with mocked HTTP (nock). They **must not** contain real data from live Zephyr or Jira, so they can be committed to GitHub safely.
+
+## What to sanitize
+
+| Data | Replace with | Example |
+|------|--------------|--------|
+| Real Jira/Zephyr base URLs | Generic or placeholder | `https://api.zephyrscale.smartbear.com` (generic) or `https://example.atlassian.net` |
+| Account IDs, user IDs | Placeholder IDs | `account-id-1`, `user-123` |
+| Real display names / emails | Placeholder strings | `Test User`, `test@example.com` |
+| Real project keys (if sensitive) | Generic keys | `PROJ`, `CP` (CP is often used as public example) |
+| Real test plan/cycle/case keys | Generic keys | `PROJ-P1`, `PROJ-R1`, `PROJ-T1` |
+| Tokens, API keys | Placeholder | `test-token`, never real tokens |
+| Tenant-specific IDs | Small integers or placeholders | `10000`, `1`, `2` |
+| Dates | Fixed or relative | `2024-01-01` or keep if not sensitive |
+
+## Rules
+
+1. **Never commit** responses copied directly from a live system without sanitizing.
+2. **Prefer synthetic data**: build minimal JSON that matches the API shape (see Zephyr types in `src/types/zephyr-types.ts`).
+3. **Self links**: use generic host or omit; do not include real tenant hostnames.
+4. **createdBy / executedBy**: use `{ "accountId": "test-account", "displayName": "Test User" }` or omit.
+5. **Project keys**: `CP` is commonly used in public Zephyr examples; otherwise use `PROJ` or `ABC`.
+
+## Fixture inventory (Zephyr)
+
+| Fixture | Purpose | Sanitized |
+|---------|---------|-----------|
+| testplans-list.json | GET /testplans (list) | Yes – synthetic |
+| testplan-get.json | GET /testplans/{key} (single) | Yes – synthetic |
+| testcycles-list.json | GET /testcycles (list) | Yes – synthetic |
+| testcycle-get.json | GET /testcycles/{key} (single) | Yes – synthetic |
+| testcases-search.json | GET /testcases/search | Yes – synthetic |
+| testcase-get.json | GET /testcases/{key} | Yes – synthetic |
+| testcase-create.json | POST /testcases (response) | Yes – synthetic |
+| teststeps-list.json | GET /testcases/{key}/teststeps | Yes – synthetic |
+| projects-list.json | GET /projects | Yes – synthetic |
+| folders-list.json | GET /folders | Yes – synthetic |
+| priorities-list.json | GET /priorities | Yes – synthetic |
+| statuses-list.json | GET /statuses | Yes – synthetic |
+| testexecution-create.json | POST /testexecutions (response) | Yes – synthetic |
+| testexecutions-in-cycle.json | GET /testexecutions?testCycle= | Yes – synthetic |
+
+When adding new fixtures, update this table and ensure no real account IDs, names, or tenant URLs are present.

--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -1,5 +1,14 @@
 # Service tests: strategy
 
+## Test layers
+
+| Layer | What | How | Run |
+|-------|------|-----|-----|
+| **Integration (mocked)** | Zephyr client with all API calls mocked | nock + fixtures; fake Jira URL and tokens only; no .env or real credentials | `npm run test:integration` or `npm run test:unit` |
+| **Contract** | Real Zephyr API (read-only) | No mocks; `.env` / secrets; assert response shape | `npm run test:contract` |
+
+We do **not** have separate “unit” tests in the narrow sense (e.g. pure functions only). The mocked suite is **integration tests** (mocked responses for all calls).
+
 ## Goal
 
 - **Mock** Zephyr (and optionally Jira) API responses.
@@ -32,8 +41,8 @@
    - Cover every `this.client.get/post/put/delete` in `zephyr-client.ts` (and later `jira-client.ts`) at least once.
 
 7. **GHA workflow**  
-   - `.github/workflows/test.yml`: on push/PR to main and feat/**; install deps, run `npm run test`, then `npm run typecheck`.  
-   - No secrets needed; all requests are mocked.
+   - **Integration (mocked):** `.github/workflows/test.yml` on push/PR to main and feat/**; `npm run test:unit` (same as `test:integration`), `npm run typecheck`. No secrets; all requests mocked.  
+   - **Contract:** `.github/workflows/contract.yml` is **manual only** (`workflow_dispatch`) for now; run once repo secrets are set. Required secrets: `ZEPHYR_BASE_URL`, `ZEPHYR_API_TOKEN`, `JIRA_BASE_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN`; optional: `ZEPHYR_CONTRACT_PROJECT_KEY`, `ZEPHYR_CONTRACT_PLAN_KEY`, `ZEPHYR_CONTRACT_CYCLE_KEY`. You can add a schedule later (e.g. daily) and a badge: `![Zephyr contract](https://github.com/OWNER/REPO/actions/workflows/contract.yml/badge.svg)`.
 
 ## Suggested layout
 
@@ -58,11 +67,13 @@ tests/
 
 ## Implementation (done)
 
-1. **nock** and **vitest** added as devDependencies; **`npm run test`** runs `vitest run`, **`npm run test:watch`** runs vitest in watch mode.
-2. **tests/setup.ts** sets minimal `process.env` so `getAppConfig()` passes when the client is created.
-3. **tests/zephyr-client.test.ts** tests four client methods with nock and fixtures: `getTestPlans`, `searchTestCases`, `createTestCase`, `getTestSteps`.
-4. **.github/workflows/test.yml** runs on push/PR to main and feat/**: `npm ci`, `npm run test`, `npm run typecheck`.
-5. **Next:** Add fixtures and tests for the remaining Zephyr client methods (test plans create, test cycles, folders, priorities, statuses, executions, test script, steps create/update/delete, etc.), then Jira client if desired.
+1. **nock** and **vitest** added as devDependencies; **`npm run test`** runs all; **`npm run test:integration`** / **`npm run test:unit`** run integration (mocked) only; **`npm run test:contract`** runs contract only; **`npm run test:watch`** runs vitest in watch mode.
+2. **tests/setup.ts** loads `.env` (for contract tests). Integration tests need no real config: they set fake Jira endpoint and fake tokens in their own `beforeAll` so nock intercepts; no .env required.
+3. **tests/zephyr-client.test.ts** = **integration tests (mocked):** Zephyr client with nock and sanitized fixtures; each test asserts request (method, path, query, body) and response shape (`scope.isDone()`).
+4. **.github/workflows/test.yml** runs on push/PR: `npm run test:unit` (integration mocked), `npm run typecheck`. No secrets.
+5. **Contract suite:** **tests/contract/zephyr-contract.test.ts** calls the real Zephyr API (read-only). Its `beforeAll` calls `dotenv.config()` so real credentials are used. **.github/workflows/contract.yml** runs `npm run test:contract` on manual trigger (`workflow_dispatch` only for now).
+6. **Run by file:** `npm run test` = all; `npm run test:integration` or `npm run test:unit` = integration (mocked) only; `npm run test:contract` = contract only.
+7. **Fixtures** are sanitized (see `docs/FIXTURE-SANITIZATION.md`); no real account IDs, names, or tokens in repo.
 
 ## Alternatives considered
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "dev": "tsup src/index.ts --format esm --dts --watch",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "test:integration": "vitest run tests/zephyr-client.test.ts",
+    "test:unit": "vitest run tests/zephyr-client.test.ts",
+    "test:contract": "vitest run tests/contract",
     "test:watch": "vitest",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit"

--- a/tests/contract/zephyr-contract.test.ts
+++ b/tests/contract/zephyr-contract.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Contract tests: run against real Zephyr API.
+ *
+ * Required env (for CI: set as repo secrets; local: .env):
+ *   - ZEPHYR_BASE_URL (e.g. https://eu.api.zephyrscale.smartbear.com/v2)
+ *   - ZEPHYR_API_TOKEN
+ *   - JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN (client validates config)
+ *
+ * Optional (for get-by-key tests):
+ *   - ZEPHYR_CONTRACT_PROJECT_KEY (default CP)
+ *   - ZEPHYR_CONTRACT_PLAN_KEY (e.g. CP-P1)
+ *   - ZEPHYR_CONTRACT_CYCLE_KEY (e.g. CP-R1)
+ *
+ * Run: npm run test:contract (contract only) | npm run test (all) | npm run test:integration (integration mocked only)
+ */
+import { config } from 'dotenv';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ZephyrClient } from '../../src/clients/zephyr-client.js';
+
+describe('Zephyr API contract', () => {
+  let client: ZephyrClient;
+
+  beforeAll(() => {
+    config(); // reload .env so we use real credentials even if unit tests ran first
+    client = new ZephyrClient();
+  });
+
+  it('GET /projects returns array-like list with id and key', async () => {
+    const result = await client.getProjects(10, 0);
+    expect(result).toHaveProperty('projects');
+    expect(result).toHaveProperty('total');
+    expect(Array.isArray(result.projects)).toBe(true);
+    expect(result.total).toBeGreaterThanOrEqual(0);
+    for (const p of result.projects) {
+      expect(p).toHaveProperty('id');
+      expect(p).toHaveProperty('key');
+      expect(typeof p.id).toBe('number');
+      expect(typeof p.key).toBe('string');
+    }
+  });
+
+  it('GET /testplans with projectKey returns list with total', async () => {
+    const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY || 'CP';
+    const result = await client.getTestPlans(projectKey, 10, 0);
+    expect(result).toHaveProperty('testPlans');
+    expect(result).toHaveProperty('total');
+    expect(Array.isArray(result.testPlans)).toBe(true);
+    if (result.testPlans.length > 0) {
+      const plan = result.testPlans[0];
+      expect(plan).toHaveProperty('id');
+      expect(plan).toHaveProperty('key');
+      expect(plan).toHaveProperty('name');
+    }
+  });
+
+  it('GET /testcycles with projectKey returns list with executionSummary', async () => {
+    const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY || 'CP';
+    const result = await client.getTestCycles(projectKey, undefined, 10);
+    expect(result).toHaveProperty('testCycles');
+    expect(result).toHaveProperty('total');
+    expect(Array.isArray(result.testCycles)).toBe(true);
+    if (result.testCycles.length > 0) {
+      const cycle = result.testCycles[0];
+      expect(cycle).toHaveProperty('id');
+      expect(cycle).toHaveProperty('key');
+      expect(cycle).toHaveProperty('name');
+      if ('executionSummary' in cycle && cycle.executionSummary != null) {
+        expect(cycle.executionSummary).toHaveProperty('total');
+      }
+    }
+  });
+
+  it.skipIf(!process.env.ZEPHYR_CONTRACT_PLAN_KEY)(
+    'GET /testplans/{key} returns single plan when key exists',
+    async () => {
+      const planKey = process.env.ZEPHYR_CONTRACT_PLAN_KEY!;
+      const result = await client.getTestPlan(planKey);
+      expect(result).toHaveProperty('key', planKey);
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('name');
+    }
+  );
+
+  it.skipIf(!process.env.ZEPHYR_CONTRACT_CYCLE_KEY)(
+    'GET /testcycles/{key} returns single cycle when key exists',
+    async () => {
+      const cycleKey = process.env.ZEPHYR_CONTRACT_CYCLE_KEY!;
+      const result = await client.getTestCycle(cycleKey);
+      expect(result).toHaveProperty('key', cycleKey);
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('name');
+      expect(result).toHaveProperty('executionSummary');
+    }
+  );
+});

--- a/tests/fixtures/zephyr/folders-list.json
+++ b/tests/fixtures/zephyr/folders-list.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    { "id": 1, "name": "Folder A", "projectKey": "PROJ", "parentId": null, "folderType": "TEST_CASE" },
+    { "id": 2, "name": "Folder B", "projectKey": "PROJ", "parentId": 1, "folderType": "TEST_CASE" }
+  ],
+  "total": 2
+}

--- a/tests/fixtures/zephyr/priorities-list.json
+++ b/tests/fixtures/zephyr/priorities-list.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    { "id": 1, "name": "High" },
+    { "id": 2, "name": "Medium" },
+    { "id": 3, "name": "Low" }
+  ]
+}

--- a/tests/fixtures/zephyr/projects-list.json
+++ b/tests/fixtures/zephyr/projects-list.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    { "id": 924, "key": "CR", "name": "Project CR" },
+    { "id": 20239, "key": "CP", "name": "Project CP" }
+  ],
+  "total": 2
+}

--- a/tests/fixtures/zephyr/statuses-list.json
+++ b/tests/fixtures/zephyr/statuses-list.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    { "id": 1, "name": "Draft" },
+    { "id": 2, "name": "Approved" }
+  ]
+}

--- a/tests/fixtures/zephyr/testcase-get.json
+++ b/tests/fixtures/zephyr/testcase-get.json
@@ -1,0 +1,13 @@
+{
+  "id": 1001,
+  "key": "PROJ-T1",
+  "name": "Sample test case",
+  "project": { "id": 10000 },
+  "folder": { "id": 200 },
+  "status": { "id": 1 },
+  "priority": { "id": 2 },
+  "objective": null,
+  "precondition": null,
+  "labels": [],
+  "links": { "issues": [] }
+}

--- a/tests/fixtures/zephyr/testcycle-get.json
+++ b/tests/fixtures/zephyr/testcycle-get.json
@@ -1,0 +1,21 @@
+{
+  "id": 200,
+  "key": "PROJ-R1",
+  "name": "Sample cycle",
+  "description": "Cycle for tests",
+  "projectId": "10000",
+  "versionId": "1",
+  "status": { "id": 365024 },
+  "plannedStartDate": "2024-01-01T00:00:00Z",
+  "plannedEndDate": "2024-12-31T23:59:59Z",
+  "createdOn": "2024-01-01T00:00:00Z",
+  "updatedOn": "2024-01-02T00:00:00Z",
+  "executionSummary": {
+    "total": 5,
+    "passed": 2,
+    "failed": 0,
+    "blocked": 0,
+    "inProgress": 0,
+    "notExecuted": 3
+  }
+}

--- a/tests/fixtures/zephyr/testcycles-list.json
+++ b/tests/fixtures/zephyr/testcycles-list.json
@@ -1,0 +1,17 @@
+{
+  "values": [
+    {
+      "id": 200,
+      "key": "PROJ-R1",
+      "name": "Cycle 1",
+      "description": "First cycle",
+      "projectId": "10000",
+      "versionId": "1",
+      "status": { "id": 365024 },
+      "plannedStartDate": "2024-01-01T00:00:00Z",
+      "plannedEndDate": "2024-12-31T23:59:59Z",
+      "executionSummary": { "total": 2, "passed": 1, "failed": 0, "blocked": 0, "inProgress": 0, "notExecuted": 1 }
+    }
+  ],
+  "total": 1
+}

--- a/tests/fixtures/zephyr/testexecution-create.json
+++ b/tests/fixtures/zephyr/testexecution-create.json
@@ -1,0 +1,7 @@
+{
+  "id": 5001,
+  "key": "PROJ-E1",
+  "testCaseId": "1001",
+  "testCycleId": "200",
+  "status": "NOT_EXECUTED"
+}

--- a/tests/fixtures/zephyr/testexecutions-in-cycle.json
+++ b/tests/fixtures/zephyr/testexecutions-in-cycle.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    { "id": 5001, "key": "PROJ-E1", "testCase": { "key": "PROJ-T1" }, "status": "NOT_EXECUTED" },
+    { "id": 5002, "key": "PROJ-E2", "testCase": { "key": "PROJ-T2" }, "status": "PASS" }
+  ],
+  "total": 2
+}

--- a/tests/fixtures/zephyr/testplan-get.json
+++ b/tests/fixtures/zephyr/testplan-get.json
@@ -1,0 +1,11 @@
+{
+  "id": 100,
+  "key": "TP-1",
+  "name": "Test Plan 1",
+  "description": "Sample plan",
+  "projectId": "10000",
+  "status": { "id": 365027 },
+  "createdOn": "2024-01-01T00:00:00Z",
+  "updatedOn": "2024-01-02T00:00:00Z",
+  "createdBy": { "accountId": "test-account", "displayName": "Test User" }
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,9 +1,6 @@
 /**
- * Test setup: set minimal env so getAppConfig() passes when the client is created.
- * Must run before any code that imports config or ZephyrClient.
+ * Test setup: load .env so real credentials are available for contract tests.
+ * Unit tests must set dummy env in their own beforeAll so nock intercepts (see zephyr-client.test.ts).
  */
-process.env.JIRA_BASE_URL = 'https://example.atlassian.net';
-process.env.JIRA_USERNAME = 'test@example.com';
-process.env.JIRA_API_TOKEN = 'test-jira-token';
-process.env.ZEPHYR_API_TOKEN = 'test-zephyr-token';
-process.env.ZEPHYR_BASE_URL = 'https://api.zephyrscale.smartbear.com/v2';
+import { config } from 'dotenv';
+config();

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -1,5 +1,8 @@
 /**
- * Service tests for ZephyrClient: mock Zephyr API responses and assert client behaviour.
+ * Integration tests for ZephyrClient: mocked responses for all Zephyr API calls (nock).
+ * Asserts request shape (method, path, query, body) and response handling.
+ * No real credentials or .env needed — uses fake Jira endpoint, fake tokens, and fixtures only.
+ * All fixtures are sanitized (no real account IDs, names, or tenant URLs). See docs/FIXTURE-SANITIZATION.md.
  * Import nock first so it patches http before the client's axios is used.
  */
 import nock from 'nock';
@@ -18,11 +21,22 @@ function loadFixture(name: string): unknown {
 }
 
 const ZEPHYR_ORIGIN = 'https://api.zephyrscale.smartbear.com';
+const V2 = '/v2';
 
-describe('ZephyrClient', () => {
+/** Fake env for integration tests only; no real credentials or .env required. */
+const INTEGRATION_DUMMY_ENV = {
+  JIRA_BASE_URL: 'https://example.atlassian.net',
+  JIRA_USERNAME: 'test@example.com',
+  JIRA_API_TOKEN: 'test-jira-token',
+  ZEPHYR_API_TOKEN: 'test-zephyr-token',
+  ZEPHYR_BASE_URL: 'https://api.zephyrscale.smartbear.com/v2',
+};
+
+describe('ZephyrClient (integration, mocked)', () => {
   let client: ZephyrClient;
 
   beforeAll(() => {
+    Object.assign(process.env, INTEGRATION_DUMMY_ENV);
     client = new ZephyrClient();
   });
 
@@ -31,10 +45,10 @@ describe('ZephyrClient', () => {
   });
 
   describe('getTestPlans', () => {
-    it('returns normalized testPlans and total from API', async () => {
+    it('sends GET /v2/testplans with projectKey and pagination, returns normalized list', async () => {
       const body = loadFixture('testplans-list.json');
-      nock(ZEPHYR_ORIGIN)
-        .get('/v2/testplans')
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testplans`)
         .query({ projectKey: 'CP', maxResults: 50, startAt: 0 })
         .reply(200, body);
 
@@ -44,31 +58,164 @@ describe('ZephyrClient', () => {
       expect(result.testPlans).toHaveLength(1);
       expect(result.testPlans[0].key).toBe('TP-1');
       expect(result.testPlans[0].name).toBe('Test Plan 1');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getTestPlan', () => {
+    it('sends GET /v2/testplans/{key} and returns single plan', async () => {
+      const body = loadFixture('testplan-get.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testplans/TP-1`)
+        .reply(200, body);
+
+      const result = await client.getTestPlan('TP-1');
+
+      expect(result.key).toBe('TP-1');
+      expect(result.name).toBe('Test Plan 1');
+      expect(result.id).toBe(100);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getTestCycles', () => {
+    it('sends GET /v2/testcycles with projectKey and optional versionId, returns list', async () => {
+      const body = loadFixture('testcycles-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcycles`)
+        .query({ projectKey: 'PROJ', maxResults: 50 })
+        .reply(200, body);
+
+      const result = await client.getTestCycles('PROJ');
+
+      expect(result.total).toBe(1);
+      expect(result.testCycles[0].key).toBe('PROJ-R1');
+      expect(result.testCycles[0].name).toBe('Cycle 1');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getTestCycle', () => {
+    it('sends GET /v2/testcycles/{key} and returns single cycle', async () => {
+      const body = loadFixture('testcycle-get.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcycles/PROJ-R1`)
+        .reply(200, body);
+
+      const result = await client.getTestCycle('PROJ-R1');
+
+      expect(result.key).toBe('PROJ-R1');
+      expect(result.name).toBe('Sample cycle');
+      expect(result.executionSummary.total).toBe(5);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getProjects', () => {
+    it('sends GET /v2/projects with maxResults and startAt, returns list', async () => {
+      const body = loadFixture('projects-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/projects`)
+        .query({ maxResults: 20, startAt: 0 })
+        .reply(200, body);
+
+      const result = await client.getProjects(20, 0);
+
+      expect(result.total).toBe(2);
+      expect(result.projects).toHaveLength(2);
+      expect(result.projects[0].key).toBe('CR');
+      expect(result.projects[1].key).toBe('CP');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getFolders', () => {
+    it('sends GET /v2/folders with projectKey and pagination', async () => {
+      const body = loadFixture('folders-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/folders`)
+        .query({ projectKey: 'PROJ', maxResults: 50, startAt: 0 })
+        .reply(200, body);
+
+      const result = await client.getFolders('PROJ');
+
+      expect(result.folders).toHaveLength(2);
+      expect(result.folders[0].name).toBe('Folder A');
+      expect(result.total).toBe(2);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getPriorities', () => {
+    it('sends GET /v2/priorities with optional projectKey', async () => {
+      const body = loadFixture('priorities-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/priorities`)
+        .query({ projectKey: 'PROJ' })
+        .reply(200, body);
+
+      const result = await client.getPriorities('PROJ');
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('High');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getStatuses', () => {
+    it('sends GET /v2/statuses with optional projectKey', async () => {
+      const body = loadFixture('statuses-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/statuses`)
+        .query({ projectKey: 'PROJ' })
+        .reply(200, body);
+
+      const result = await client.getStatuses('PROJ');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Draft');
+      expect(scope.isDone()).toBe(true);
     });
   });
 
   describe('searchTestCases', () => {
-    it('returns normalized testCases and total from search', async () => {
+    it('sends GET /v2/testcases/search with projectKey and maxResults', async () => {
       const body = loadFixture('testcases-search.json');
-      nock(ZEPHYR_ORIGIN)
-        .get('/v2/testcases/search')
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcases/search`)
         .query({ projectKey: 'CP', maxResults: 50 })
         .reply(200, body);
 
       const result = await client.searchTestCases('CP', undefined, 50);
 
       expect(result.total).toBe(1);
-      expect(result.testCases).toHaveLength(1);
       expect(result.testCases[0].key).toBe('CP-T1');
       expect(result.testCases[0].name).toBe('Sample test case');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getTestCase', () => {
+    it('sends GET /v2/testcases/{key} and returns single test case', async () => {
+      const body = loadFixture('testcase-get.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcases/PROJ-T1`)
+        .reply(200, body);
+
+      const result = await client.getTestCase('PROJ-T1');
+
+      expect(result.key).toBe('PROJ-T1');
+      expect(result.name).toBe('Sample test case');
+      expect(result.id).toBe(1001);
+      expect(scope.isDone()).toBe(true);
     });
   });
 
   describe('createTestCase', () => {
-    it('posts payload and returns created test case', async () => {
+    it('sends POST /v2/testcases with expected body and returns created case', async () => {
       const body = loadFixture('testcase-create.json');
-      nock(ZEPHYR_ORIGIN)
-        .post('/v2/testcases', (reqBody: Record<string, unknown>) => {
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/testcases`, (reqBody: Record<string, unknown>) => {
           return reqBody.name === 'New case' && reqBody.projectKey === 'CP';
         })
         .reply(200, body);
@@ -81,14 +228,15 @@ describe('ZephyrClient', () => {
       expect(result.key).toBe('CP-T2');
       expect(result.name).toBe('Created test case');
       expect(result.id).toBe(1002);
+      expect(scope.isDone()).toBe(true);
     });
   });
 
   describe('getTestSteps', () => {
-    it('returns normalized steps from API', async () => {
+    it('sends GET /v2/testcases/{key}/teststeps and returns normalized steps', async () => {
       const body = loadFixture('teststeps-list.json');
-      nock(ZEPHYR_ORIGIN)
-        .get('/v2/testcases/CP-T1/teststeps')
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcases/CP-T1/teststeps`)
         .reply(200, body);
 
       const result = await client.getTestSteps('CP-T1');
@@ -97,6 +245,65 @@ describe('ZephyrClient', () => {
       expect(result[0].description).toBe('Step one');
       expect(result[0].expectedResult).toBe('Result one');
       expect(result[0].id).toBe(1);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('createTestExecution', () => {
+    it('sends POST /v2/testexecutions with projectKey, testCaseKey, testCycleKey, statusName', async () => {
+      const body = loadFixture('testexecution-create.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/testexecutions`, (reqBody: Record<string, unknown>) => {
+          return (
+            reqBody.projectKey === 'PROJ' &&
+            reqBody.testCaseKey === 'PROJ-T1' &&
+            reqBody.testCycleKey === 'PROJ-R1' &&
+            (reqBody.statusName === 'Not Executed' || reqBody.statusName === undefined)
+          );
+        })
+        .reply(200, body);
+
+      const result = await client.createTestExecution({
+        projectKey: 'PROJ',
+        testCaseKey: 'PROJ-T1',
+        testCycleKey: 'PROJ-R1',
+        statusName: 'Not Executed',
+      });
+
+      expect(result.id).toBe(5001);
+      expect(result.key).toBe('PROJ-E1');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getTestExecutionsInCycle', () => {
+    it('sends GET /v2/testexecutions with query testCycle', async () => {
+      const body = loadFixture('testexecutions-in-cycle.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testexecutions`)
+        .query({ testCycle: 'PROJ-R1' })
+        .reply(200, body);
+
+      const result = await client.getTestExecutionsInCycle('PROJ-R1');
+
+      expect(result.total).toBe(2);
+      expect(result.executions).toHaveLength(2);
+      expect(result.executions[0].key).toBe('PROJ-E1');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('linkTestCaseToIssue', () => {
+    it('sends POST /v2/testcases/{id}/links with issueKeys array', async () => {
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/testcases/PROJ-T1/links`, (reqBody: Record<string, unknown>) => {
+          return Array.isArray(reqBody.issueKeys) && reqBody.issueKeys.includes('PROJ-123');
+        })
+        .reply(204);
+
+      await client.linkTestCaseToIssue('PROJ-T1', 'PROJ-123');
+
+      expect(scope.isDone()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Integration tests (mocked):** ZephyrClient tests with nock + sanitized fixtures; assert request (method, path, query, body) and response. No real credentials or .env required. Run: `npm run test:integration` or `npm run test:unit`.
- **Contract tests:** Real Zephyr API (read-only) in `tests/contract/`. Run: `npm run test:contract` (requires .env or secrets).
- **CI:** Test workflow runs on push/PR with integration tests + typecheck (no secrets). Contract workflow is **manual only** (`workflow_dispatch`) for now; schedule can be re-enabled once repo secrets are set.
- **Docs:** TESTING-STRATEGY.md, FIXTURE-SANITIZATION.md; README badge for contract.

GitHub CI should pass with the integration tests.