### PR TITLE
Add integration tests (mocked), contract suite; contract workflow manual only

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,7 +1,8 @@
 # Zephyr integration contract tests (real API).
 # Manual only for now (workflow_dispatch). Re-enable schedule once repo secrets are set.
 # Required secrets: ZEPHYR_BASE_URL, ZEPHYR_API_TOKEN, JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN
-# Optional: ZEPHYR_CONTRACT_PROJECT_KEY, ZEPHYR_CONTRACT_PLAN_KEY, ZEPHYR_CONTRACT_CYCLE_KEY
+# Optional but needed for testplans/testcycles list tests: ZEPHYR_CONTRACT_PROJECT_KEY (your project key)
+# Optional for get-by-key tests: ZEPHYR_CONTRACT_PLAN_KEY, ZEPHYR_CONTRACT_CYCLE_KEY
 name: Zephyr contract
 
 on:

--- a/tests/contract/zephyr-contract.test.ts
+++ b/tests/contract/zephyr-contract.test.ts
@@ -6,10 +6,10 @@
  *   - ZEPHYR_API_TOKEN
  *   - JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN (client validates config)
  *
- * Optional (for get-by-key tests):
- *   - ZEPHYR_CONTRACT_PROJECT_KEY (default CP)
- *   - ZEPHYR_CONTRACT_PLAN_KEY (e.g. CP-P1)
- *   - ZEPHYR_CONTRACT_CYCLE_KEY (e.g. CP-R1)
+ * Optional (required for testplans/testcycles list tests; no default):
+ *   - ZEPHYR_CONTRACT_PROJECT_KEY (your Jira project key, e.g. MYPROJ)
+ *   - ZEPHYR_CONTRACT_PLAN_KEY (e.g. MYPROJ-P1)
+ *   - ZEPHYR_CONTRACT_CYCLE_KEY (e.g. MYPROJ-R1)
  *
  * Run: npm run test:contract (contract only) | npm run test (all) | npm run test:integration (integration mocked only)
  */
@@ -39,36 +39,42 @@ describe('Zephyr API contract', () => {
     }
   });
 
-  it('GET /testplans with projectKey returns list with total', async () => {
-    const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY || 'CP';
-    const result = await client.getTestPlans(projectKey, 10, 0);
-    expect(result).toHaveProperty('testPlans');
-    expect(result).toHaveProperty('total');
-    expect(Array.isArray(result.testPlans)).toBe(true);
-    if (result.testPlans.length > 0) {
-      const plan = result.testPlans[0];
-      expect(plan).toHaveProperty('id');
-      expect(plan).toHaveProperty('key');
-      expect(plan).toHaveProperty('name');
-    }
-  });
-
-  it('GET /testcycles with projectKey returns list with executionSummary', async () => {
-    const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY || 'CP';
-    const result = await client.getTestCycles(projectKey, undefined, 10);
-    expect(result).toHaveProperty('testCycles');
-    expect(result).toHaveProperty('total');
-    expect(Array.isArray(result.testCycles)).toBe(true);
-    if (result.testCycles.length > 0) {
-      const cycle = result.testCycles[0];
-      expect(cycle).toHaveProperty('id');
-      expect(cycle).toHaveProperty('key');
-      expect(cycle).toHaveProperty('name');
-      if ('executionSummary' in cycle && cycle.executionSummary != null) {
-        expect(cycle.executionSummary).toHaveProperty('total');
+  it.skipIf(!process.env.ZEPHYR_CONTRACT_PROJECT_KEY)(
+    'GET /testplans with projectKey returns list with total',
+    async () => {
+      const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY!;
+      const result = await client.getTestPlans(projectKey, 10, 0);
+      expect(result).toHaveProperty('testPlans');
+      expect(result).toHaveProperty('total');
+      expect(Array.isArray(result.testPlans)).toBe(true);
+      if (result.testPlans.length > 0) {
+        const plan = result.testPlans[0];
+        expect(plan).toHaveProperty('id');
+        expect(plan).toHaveProperty('key');
+        expect(plan).toHaveProperty('name');
       }
     }
-  });
+  );
+
+  it.skipIf(!process.env.ZEPHYR_CONTRACT_PROJECT_KEY)(
+    'GET /testcycles with projectKey returns list with executionSummary',
+    async () => {
+      const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY!;
+      const result = await client.getTestCycles(projectKey, undefined, 10);
+      expect(result).toHaveProperty('testCycles');
+      expect(result).toHaveProperty('total');
+      expect(Array.isArray(result.testCycles)).toBe(true);
+      if (result.testCycles.length > 0) {
+        const cycle = result.testCycles[0];
+        expect(cycle).toHaveProperty('id');
+        expect(cycle).toHaveProperty('key');
+        expect(cycle).toHaveProperty('name');
+        if ('executionSummary' in cycle && cycle.executionSummary != null) {
+          expect(cycle.executionSummary).toHaveProperty('total');
+        }
+      }
+    }
+  );
 
   it.skipIf(!process.env.ZEPHYR_CONTRACT_PLAN_KEY)(
     'GET /testplans/{key} returns single plan when key exists',


### PR DESCRIPTION
## Summary

- **Integration tests (mocked):** ZephyrClient tests with nock + sanitized fixtures; assert request (method, path, query, body) and response. No real credentials or .env required. Run: `npm run test:integration` or `npm run test:unit`.
- **Contract tests:** Real Zephyr API (read-only) in `tests/contract/`. Run: `npm run test:contract` (requires .env or secrets). No hardcoded project key — set `ZEPHYR_CONTRACT_PROJECT_KEY` to run testplans/testcycles list tests.
- **CI:** Test workflow runs on push/PR with integration tests + typecheck (no secrets). Contract workflow is manual only (`workflow_dispatch`).
- **Docs:** TESTING-STRATEGY.md, FIXTURE-SANITIZATION.md; README badge for contract.