### PR TITLE
Contract workflow: document JIRA_BASE_URL and secrets, default ZEPHYR_BASE_URL to US

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,8 +1,14 @@
 # Zephyr integration contract tests (real API).
-# Manual only for now (workflow_dispatch). Re-enable schedule once repo secrets are set.
-# Required secrets: ZEPHYR_BASE_URL, ZEPHYR_API_TOKEN, JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN
-# Optional but needed for testplans/testcycles list tests: ZEPHYR_CONTRACT_PROJECT_KEY (your project key)
-# Optional for get-by-key tests: ZEPHYR_CONTRACT_PLAN_KEY, ZEPHYR_CONTRACT_CYCLE_KEY
+# Manual only (workflow_dispatch). Set repo secrets under Settings → Secrets and variables → Actions.
+#
+# Required secrets (must match these exact names):
+#   JIRA_BASE_URL   - e.g. https://your-domain.atlassian.net
+#   JIRA_USERNAME   - Jira account email
+#   JIRA_API_TOKEN  - Jira API token
+#   ZEPHYR_API_TOKEN - Zephyr Scale API token
+# For non-EU / US Zephyr, ZEPHYR_BASE_URL is not needed (we default to US endpoint).
+# Optional: ZEPHYR_BASE_URL (e.g. https://eu.api.zephyrscale.smartbear.com/v2 for EU)
+# Optional: ZEPHYR_CONTRACT_PROJECT_KEY, ZEPHYR_CONTRACT_PLAN_KEY, ZEPHYR_CONTRACT_CYCLE_KEY
 name: Zephyr contract
 
 on:
@@ -25,11 +31,11 @@ jobs:
 
       - name: Run Zephyr contract tests
         env:
-          ZEPHYR_BASE_URL: ${{ secrets.ZEPHYR_BASE_URL }}
-          ZEPHYR_API_TOKEN: ${{ secrets.ZEPHYR_API_TOKEN }}
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ZEPHYR_API_TOKEN: ${{ secrets.ZEPHYR_API_TOKEN }}
+          ZEPHYR_BASE_URL: ${{ secrets.ZEPHYR_BASE_URL || 'https://api.zephyrscale.smartbear.com/v2' }}
           ZEPHYR_CONTRACT_PROJECT_KEY: ${{ secrets.ZEPHYR_CONTRACT_PROJECT_KEY }}
           ZEPHYR_CONTRACT_PLAN_KEY: ${{ secrets.ZEPHYR_CONTRACT_PLAN_KEY }}
           ZEPHYR_CONTRACT_CYCLE_KEY: ${{ secrets.ZEPHYR_CONTRACT_CYCLE_KEY }}


### PR DESCRIPTION
## Summary

- **Contract workflow:** Document required repo secrets (JIRA_BASE_URL, JIRA_USERNAME, JIRA_API_TOKEN, ZEPHYR_API_TOKEN) and optional ZEPHYR_BASE_URL.
- **Non-EU / US:** Default `ZEPHYR_BASE_URL` to US endpoint when the secret is not set so contract tests run without that secret.
- Reorder `env` so required vars are listed first.

Add JIRA_BASE_URL (and the other required secrets) in Settings → Secrets and variables → Actions, then run the Zephyr contract workflow manually to test in GHA.