### PR TITLE
Schedule contract daily 6am CET; add integration tests badge to README

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,5 +1,5 @@
 # Zephyr integration contract tests (real API).
-# Manual only (workflow_dispatch). Set repo secrets under Settings → Secrets and variables → Actions.
+# Runs daily at 6am CET (05:00 UTC) and on manual trigger. Set repo secrets under Settings → Secrets and variables → Actions.
 #
 # Required secrets (must match these exact names):
 #   JIRA_BASE_URL   - e.g. https://your-domain.atlassian.net
@@ -12,6 +12,9 @@
 name: Zephyr contract
 
 on:
+  schedule:
+    # 6am CET = 05:00 UTC (CEST = 04:00 UTC; we use 05:00 for CET)
+    - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An [MCP](https://modelcontextprotocol.io/) server for JIRA and **Zephyr Scale** 
 
 **Running it:** Use the published Docker image—no clone or build. Docker pulls the image when needed; you add a small config block to your AI tool (Cursor, Claude, Gemini, Windsurf, etc.). Cloning and building from source is for **developers and contributors** only.
 
-[![Zephyr contract](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml) — Zephyr API contract tests (daily / on demand).
+[![Integration tests](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/test.yml) [![Zephyr contract](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml) — Integration (PR/push) · Zephyr contract (daily 6am CET / on demand).
 
 ---
 


### PR DESCRIPTION
## Summary

- **Contract workflow:** Run on schedule daily at 6am CET (05:00 UTC); keep `workflow_dispatch` for manual runs.
- **README:** Add Integration tests badge (test.yml) alongside Zephyr contract badge; caption: Integration (PR/push) · Zephyr contract (daily 6am CET / on demand).