### PR TITLE
Fix Dependabot: set package-ecosystem to npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fixes the Dependabot config error: `package-ecosystem` was `""` (invalid). Set to `"npm"` so Dependabot can parse the file and run version updates for this repo.