### PR TITLE
chore(docker): use Node 22 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Node.js 18 as base image
-FROM node:18
+# Use Node.js 22 as base image
+FROM node:22
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
Updates the Docker base image from `node:18` to `node:22` so the published image matches the Node 22 requirement (engines + CI).