### PR TITLE
Release v0.8.1 (security fix release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-zephyr-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.8.0',
+    version: '0.8.1',
   },
   {
     capabilities: {


### PR DESCRIPTION
## v0.8.1 — security fix release

- **Version bump** to 0.8.1 in `package.json`, `package-lock.json`, and server metadata in `src/index.ts`.
- **Tag:** `v0.8.1` has been created and pushed; GitHub will show it under Releases.

This release includes Dependabot dependency updates (MCP SDK, axios, etc.), Node 22 (engines + CI), and Docker Node 22 base image. Merge to publish the version bump to main.