### PR TITLE
ci: use checkout/setup-node v5 (Node 24 action runtime)

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -21,10 +21,10 @@ jobs:
   contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Addresses the GitHub Actions warning that `actions/checkout@v4` and `actions/setup-node@v4` run on the deprecated Node.js 20 runtime for the action itself ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

### Changes
- Bump **actions/checkout** and **actions/setup-node** to **v5** in `test.yml` and `contract.yml` (v5 uses the Node 24 runtime for these actions).

### Unchanged
- **`node-version: '22'`** is unchanged: the project still builds and tests on Node 22; only the action shim runtime moves to Node 24.

### Note
- v5 of these actions requires runner **v2.327.1+** (standard on `ubuntu-latest` on GitHub-hosted runners).