### PR TITLE
fix(contract): optional executionSummary on GET /testcycles/{key}

### DIFF
--- a/src/tools/test-cycles.ts
+++ b/src/tools/test-cycles.ts
@@ -106,7 +106,7 @@ export const listTestCycles = async (input: ListTestCyclesInput) => {
       data: {
         total: result.total,
         testCycles: result.testCycles.map(cycle => {
-          const summary = cycle.executionSummary ?? {};
+          const s = cycle.executionSummary;
           return {
             id: cycle.id,
             key: cycle.key,
@@ -123,14 +123,14 @@ export const listTestCycles = async (input: ListTestCyclesInput) => {
             createdOn: cycle.createdOn,
             updatedOn: cycle.updatedOn,
             executionSummary: {
-              total: summary.total ?? 0,
-              passed: summary.passed ?? 0,
-              failed: summary.failed ?? 0,
-              blocked: summary.blocked ?? 0,
-              inProgress: summary.inProgress ?? 0,
-              notExecuted: summary.notExecuted ?? 0,
-              passRate: (summary.total ?? 0) > 0
-                ? Math.round(((summary.passed ?? 0) / (summary.total ?? 1)) * 100)
+              total: s?.total ?? 0,
+              passed: s?.passed ?? 0,
+              failed: s?.failed ?? 0,
+              blocked: s?.blocked ?? 0,
+              inProgress: s?.inProgress ?? 0,
+              notExecuted: s?.notExecuted ?? 0,
+              passRate: (s?.total ?? 0) > 0
+                ? Math.round(((s?.passed ?? 0) / (s?.total ?? 1)) * 100)
                 : 0,
             },
           };

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -28,7 +28,8 @@ export interface ZephyrTestCycle {
   actualEndDate?: string;
   createdOn: string;
   updatedOn: string;
-  executionSummary: {
+  /** Present on many list/detail responses; Zephyr Scale may omit on GET /testcycles/{key}. */
+  executionSummary?: {
     total: number;
     passed: number;
     failed: number;

--- a/tests/contract/zephyr-contract.test.ts
+++ b/tests/contract/zephyr-contract.test.ts
@@ -95,7 +95,10 @@ describe('Zephyr API contract', () => {
       expect(result).toHaveProperty('key', cycleKey);
       expect(result).toHaveProperty('id');
       expect(result).toHaveProperty('name');
-      expect(result).toHaveProperty('executionSummary');
+      // Single-cycle GET may omit executionSummary; list responses often include it.
+      if ('executionSummary' in result && result.executionSummary != null) {
+        expect(result.executionSummary).toHaveProperty('total');
+      }
     }
   );
 });


### PR DESCRIPTION
Fixes contract CI failure:

```
AssertionError: expected { … } to have property "executionSummary"
```

Zephyr Scale often includes `executionSummary` on **list** test cycle responses but **not** on **GET** `/testcycles/{key}` for some cycles/instances. The contract test now matches the list test: assert `key`, `id`, `name` always; if `executionSummary` is present, assert it has `total`.

Also:
- `ZephyrTestCycle.executionSummary` is optional in types (reflects real API).
- `listTestCycles` tool mapping uses optional chaining instead of `{}` fallback (satisfies TypeScript after the type change).

Related run: https://github.com/miklosbagi/jira-zephyr-mcp/actions/runs/23431568132/job/68160315683