### PR TITLE
feat: remove_test_case_from_cycle (delete test execution)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ The following environment variables are required:
 - `list_test_cycles`: List existing test cycles with execution status
 - `execute_test`: Update test execution results
 - `get_test_execution_status`: Get test execution progress and statistics
+- `remove_test_case_from_cycle`: Remove a test case from a cycle (delete test execution by id or cycle + case key)
 - `link_tests_to_issues`: Associate test cases with JIRA issues
 - `generate_test_report`: Generate test execution report
 - `create_test_case`: Create a new test case in Zephyr

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **list_test_executions_in_cycle** | List test cases and executions in a cycle. |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
+| **remove_test_case_from_cycle** | Remove a test case from a cycle by deleting its test execution (`DELETE /testexecutions/{id}`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve it. If the public API returns 404/405 on your instance, use the Zephyr UI or contact SmartBear. |
 | **create_test_case** / **search_test_cases** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
 | **execute_test** | Update test execution status (PASS/FAIL/WIP/BLOCKED). |
@@ -157,6 +158,9 @@ list_test_executions_in_cycle({ cycleId: "ABC-R1" });
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
 create_test_execution({ projectKey: "ABC", testCycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
+// Remove from cycle: by execution id, or by cycle + case key
+remove_test_case_from_cycle({ executionId: "12345" });
+remove_test_case_from_cycle({ cycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
 ```
 
 **Folders**
@@ -266,7 +270,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [ ] **Environments** — List or manage environments for cycles.
 - [ ] **Test case archive / delete** — Archive and delete test cases (per Zephyr docs).
 - [x] **Test steps as separate resource** — `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` (v0.7). Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER.
-- [ ] **Remove test case from cycle** — Remove a test from a cycle (if supported by API).
+- [x] **Remove test case from cycle** — `remove_test_case_from_cycle` calls `DELETE /testexecutions/{id}` (resolve via `list_test_executions_in_cycle` or pass `cycleKey` + `testCaseKey`). Official docs may not advertise this; some tenants return 404/405.
 - [ ] **Update test plan / test cycle** — PUT for plans and cycles (rename, dates, status).
 - [ ] **Bulk operations** — Bulk execution updates or bulk add-to-cycle (beyond `create_multiple_test_cases`).
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -90,8 +90,9 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 12. **Remove test case from cycle**
 
-- **API:** DELETE or similar for “test case in cycle” association (if documented).
-- **Gap:** No tool to remove a test case from a cycle. Only “add to cycle” is missing; “remove from cycle” would complete the lifecycle.
+- **API (used):** `DELETE /testexecutions/{executionId}` — removing the execution removes the test case from the cycle (same net effect as the UI in typical setups).
+- **MCP status:** Implemented (`remove_test_case_from_cycle`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve a single matching execution. If more than one execution exists for the same case in the cycle, you must pass **`executionId`**.
+- **Caveat:** The public API reference does not always list this operation; some tenants return **404/405**. The Zephyr UI may use other backends for bulk removal; this tool targets the Scale Cloud v2 REST surface only.
 
 ### 13. **Update test plan / Update test cycle**
 
@@ -120,7 +121,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 9 | List/manage environments | GET (environments) | Not implemented |
 | 10 | Archive/delete test case | Archive + delete (per docs) | Not implemented |
 | 11 | Test steps CRUD | testcases/{key}/teststeps | Implemented (v0.7) |
-| 12 | Remove test case from cycle | DELETE (if exists) | Not implemented |
+| 12 | Remove test case from cycle | DELETE /testexecutions/{id} | Implemented (`remove_test_case_from_cycle`; API support varies by tenant) |
 | 13 | Update test plan / test cycle | PUT testplans, testcycles | Not implemented |
 | 14 | Bulk operations (executions, cycle) | Bulk endpoints (if any) | Not implemented |
 

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -254,6 +254,48 @@ export class ZephyrClient {
     return response.data;
   }
 
+  /**
+   * Remove a test case from a cycle by deleting its test execution (Scale Cloud v2:
+   * DELETE /testexecutions/{id}). Some instances document this poorly; if the API returns
+   * 404/405, removal may not be enabled for your tenant.
+   */
+  async deleteTestExecution(executionIdOrKey: string): Promise<void> {
+    const id = encodeURIComponent(executionIdOrKey);
+    await this.client.delete(`/testexecutions/${id}`);
+  }
+
+  /**
+   * Find the execution for testCaseKey in the cycle and delete it (same effect as removing
+   * the test case from the cycle in the UI when one execution exists per case).
+   */
+  async removeTestCaseFromCycle(cycleKey: string, testCaseKey: string): Promise<{ executionId: string }> {
+    const { executions } = await this.getTestExecutionsInCycle(cycleKey);
+    type ExRow = ZephyrTestExecution & { testCase?: { key?: string }; testCaseKey?: string };
+    const rows = executions as ExRow[];
+    const matches = rows.filter(ex => {
+      const key = ex.testCase?.key ?? ex.testCaseKey;
+      return key === testCaseKey;
+    });
+    if (matches.length === 0) {
+      throw new Error(
+        `No test execution in cycle "${cycleKey}" for test case "${testCaseKey}". Use list_test_executions_in_cycle to list executions.`
+      );
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple executions for test case "${testCaseKey}" in cycle "${cycleKey}"; pass executionId from list_test_executions_in_cycle.`
+      );
+    }
+    const match = matches[0];
+    const rawId = match.id ?? match.key;
+    if (rawId == null || rawId === '') {
+      throw new Error('Matched execution has no id or key; cannot delete.');
+    }
+    const executionId = String(rawId);
+    await this.deleteTestExecution(executionId);
+    return { executionId };
+  }
+
   async updateTestExecution(data: {
     executionId: string;
     status: 'PASS' | 'FAIL' | 'WIP' | 'BLOCKED';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { createTestPlan, listTestPlans, getTestPlan } from './tools/test-plans.j
 import { createTestCycle, listTestCycles, getTestCycle, addTestCasesToCycle, updateTestCycle } from './tools/test-cycles.js';
 import {
   createTestExecution,
+  removeTestCaseFromCycle,
   executeTest,
   getTestExecutionStatus,
   listTestExecutionsInCycle,
@@ -38,6 +39,7 @@ import {
   listTestExecutionsInCycleSchema,
   addTestCasesToCycleSchema,
   createTestExecutionSchema,
+  removeTestCaseFromCycleSchema,
   listFoldersSchema,
   createFolderSchema,
   listPrioritiesSchema,
@@ -67,6 +69,7 @@ import {
   ListTestExecutionsInCycleInput,
   AddTestCasesToCycleInput,
   CreateTestExecutionInput,
+  RemoveTestCaseFromCycleInput,
   ListFoldersInput,
   CreateFolderInput,
   ListPrioritiesInput,
@@ -257,6 +260,29 @@ const TOOLS = [
         environmentName: { type: 'string', description: 'Environment name (optional)' },
       },
       required: ['projectKey', 'testCaseKey', 'testCycleKey'],
+    },
+  },
+  {
+    name: 'remove_test_case_from_cycle',
+    description:
+      'Remove a test case from a test cycle by deleting its test execution (DELETE /testexecutions/{id}). Pass executionId from list_test_executions_in_cycle, or cycleKey + testCaseKey to resolve the execution automatically. May return 404/405 if your Zephyr instance does not expose this on the public API.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (use alone; do not combine with cycleKey/testCaseKey)',
+        },
+        cycleKey: {
+          type: 'string',
+          description: 'Test cycle key or id (required with testCaseKey if executionId is omitted)',
+        },
+        testCaseKey: {
+          type: 'string',
+          description: 'Test case key to remove from the cycle (required with cycleKey if executionId is omitted)',
+        },
+      },
+      required: [],
     },
   },
   {
@@ -761,6 +787,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await createTestExecution(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'remove_test_case_from_cycle': {
+        const validatedArgs = validateInput<RemoveTestCaseFromCycleInput>(
+          removeTestCaseFromCycleSchema,
+          args,
+          'remove_test_case_from_cycle'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await removeTestCaseFromCycle(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-execution.ts
+++ b/src/tools/test-execution.ts
@@ -6,12 +6,14 @@ import {
   linkTestsToIssuesSchema,
   generateTestReportSchema,
   createTestExecutionSchema,
+  removeTestCaseFromCycleSchema,
   ExecuteTestInput,
   GetTestExecutionStatusInput,
   ListTestExecutionsInCycleInput,
   LinkTestsToIssuesInput,
   GenerateTestReportInput,
   CreateTestExecutionInput,
+  RemoveTestCaseFromCycleInput,
 } from '../utils/validation.js';
 
 let zephyrClient: ZephyrClient | null = null;
@@ -21,6 +23,33 @@ const getZephyrClient = (): ZephyrClient => {
     zephyrClient = new ZephyrClient();
   }
   return zephyrClient;
+};
+
+export const removeTestCaseFromCycle = async (input: RemoveTestCaseFromCycleInput) => {
+  const validatedInput = removeTestCaseFromCycleSchema.parse(input);
+  try {
+    const client = getZephyrClient();
+    if (validatedInput.executionId?.trim()) {
+      const executionId = validatedInput.executionId.trim();
+      await client.deleteTestExecution(executionId);
+      return {
+        success: true,
+        data: { executionId, removed: true },
+      };
+    }
+    const cycleKey = validatedInput.cycleKey!.trim();
+    const testCaseKey = validatedInput.testCaseKey!.trim();
+    const { executionId } = await client.removeTestCaseFromCycle(cycleKey, testCaseKey);
+    return {
+      success: true,
+      data: { cycleKey, testCaseKey, executionId, removed: true },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
 };
 
 export const createTestExecution = async (input: CreateTestExecutionInput) => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -79,6 +79,34 @@ export const addTestCasesToCycleSchema = z.object({
   testCaseKeys: z.array(z.string().min(1)).min(1, 'At least one test case key is required'),
 });
 
+/** Either `executionId` alone, or `cycleKey` + `testCaseKey` together (not both). */
+export const removeTestCaseFromCycleSchema = z
+  .object({
+    executionId: z.string().optional(),
+    cycleKey: z.string().optional(),
+    testCaseKey: z.string().optional(),
+  })
+  .superRefine((val, ctx) => {
+    const exec = val.executionId?.trim();
+    const cycle = val.cycleKey?.trim();
+    const tc = val.testCaseKey?.trim();
+    if (exec && (cycle || tc)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide only executionId, or both cycleKey and testCaseKey — not both.',
+        path: ['executionId'],
+      });
+    }
+    if (!exec && (!cycle || !tc)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide executionId, or both cycleKey and testCaseKey.',
+      });
+    }
+  });
+
+export type RemoveTestCaseFromCycleInput = z.infer<typeof removeTestCaseFromCycleSchema>;
+
 export const listFoldersSchema = z.object({
   projectKey: z.string().min(1, 'Project key is required'),
   folderType: z.enum(['TEST_CASE', 'TEST_CYCLE']).optional(),

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -293,6 +293,45 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('deleteTestExecution', () => {
+    it('sends DELETE /v2/testexecutions/{id}', async () => {
+      const scope = nock(ZEPHYR_ORIGIN).delete(`${V2}/testexecutions/5001`).reply(204);
+
+      await client.deleteTestExecution('5001');
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('removeTestCaseFromCycle', () => {
+    it('lists cycle executions then DELETEs the matching test case execution', async () => {
+      const listBody = loadFixture('testexecutions-in-cycle.json');
+      const listScope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testexecutions`)
+        .query({ testCycle: 'PROJ-R1' })
+        .reply(200, listBody);
+      const delScope = nock(ZEPHYR_ORIGIN).delete(`${V2}/testexecutions/5002`).reply(204);
+
+      const result = await client.removeTestCaseFromCycle('PROJ-R1', 'PROJ-T2');
+
+      expect(result.executionId).toBe('5002');
+      expect(listScope.isDone()).toBe(true);
+      expect(delScope.isDone()).toBe(true);
+    });
+
+    it('throws when no execution matches test case key', async () => {
+      const listBody = loadFixture('testexecutions-in-cycle.json');
+      nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testexecutions`)
+        .query({ testCycle: 'PROJ-R1' })
+        .reply(200, listBody);
+
+      await expect(client.removeTestCaseFromCycle('PROJ-R1', 'PROJ-T99')).rejects.toThrow(
+        'No test execution in cycle'
+      );
+    });
+  });
+
   describe('linkTestCaseToIssue', () => {
     it('sends POST /v2/testcases/{id}/links with issueKeys array', async () => {
       const scope = nock(ZEPHYR_ORIGIN)


### PR DESCRIPTION
### Summary
Adds MCP tool **`remove_test_case_from_cycle`** to drop a test case from a cycle by deleting its **test execution** via **`DELETE /v2/testexecutions/{id}`** (same practical effect as removing the row in the UI when there is one execution per case).

### Usage
- **`executionId` only** — id or key from `list_test_executions_in_cycle`.
- **`cycleKey` + `testCaseKey`** — lists executions in the cycle, finds a **single** match, then deletes. If **multiple** executions exist for that case, the tool errors and asks for `executionId`.

### Notes
- Official docs sometimes omit this operation; some tenants return **404/405**. README and `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` document the caveat.

### Changes
- `ZephyrClient`: `deleteTestExecution`, `removeTestCaseFromCycle`
- Validation: `removeTestCaseFromCycleSchema` (XOR: id vs cycle+key)
- Tests: nock for `DELETE` and list+delete flow
- Docs: README tools + examples, roadmap, CLAUDE.md, gaps doc