### PR TITLE
ci: Docker release after label tags + GitHub Release published

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,9 @@
 # Production images: semver tag + latest (Docker Hub + GHCR), linux/amd64 + linux/arm64.
 #
 # Triggers:
-#   1) Push a semver git tag (e.g. v0.8.2) — normal release.
-#   2) workflow_dispatch — enter an existing tag to rebuild/republish (e.g. fix multi-arch
-#      or registry without re-tagging in git).
+#   1) Push a semver git tag (e.g. v0.9.0) — normal release (skips if push was via GITHUB_TOKEN only).
+#   2) workflow_dispatch — enter an existing tag to rebuild/republish.
+#   3) GitHub Release published — uses the release tag (good when you publish a release from the UI).
 #
 # Secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN; optional GH_TOKEN for GHCR (see docker-pr.yml).
 name: Docker (release)
@@ -12,6 +12,8 @@ on:
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -40,12 +42,14 @@ jobs:
               echo "::error::Input 'tag' is required."
               exit 1
             fi
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
           else
             TAG="$GITHUB_REF_NAME"
           fi
 
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "release" ]; then
               echo "::error::Tag must match vMajor.Minor.Patch (got: $TAG)"
               exit 1
             fi

--- a/.github/workflows/pr-label-version-tag.yml
+++ b/.github/workflows/pr-label-version-tag.yml
@@ -9,9 +9,9 @@
 # If more than one label is present, precedence is: tag-major > tag-minor > tag-patch.
 # If none of these labels are on the merged PR, this workflow does nothing.
 #
-# Docker release: pushes made with the default GITHUB_TOKEN do NOT trigger other workflows
-# (see GitHub docs: triggering a workflow from a workflow). Set repo secret GH_TOKEN to a
-# PAT with contents:write so git push here starts docker-release.yml on the new tag.
+# Tag pushes using GITHUB_TOKEN do not start other workflows. After pushing we dispatch
+# Docker (release) via workflow_dispatch (allowed; needs actions:write). Optional GH_TOKEN
+# is still used for git push if you set it (e.g. stricter org rules).
 #
 # Fork PRs are skipped (no contents: write on untrusted code).
 name: Version tag from PR label
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -62,10 +63,10 @@ jobs:
 
       - name: Compute next tag and push
         if: steps.bump.outputs.skip == 'false'
+        id: tagpush
         env:
           BUMP: ${{ steps.bump.outputs.bump }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # PAT required for tag push to trigger docker-release.yml; GITHUB_TOKEN pushes are ignored for downstream workflows.
           PUSH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           set -euo pipefail
@@ -95,6 +96,8 @@ jobs:
             exit 1
           fi
 
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -104,3 +107,15 @@ jobs:
           git push origin "$NEW_TAG"
 
           echo "Created and pushed $NEW_TAG"
+
+      - name: Dispatch Docker (release) workflow
+        if: steps.bump.outputs.skip == 'false' && steps.tagpush.outputs.new_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run docker-release.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f tag="${{ steps.tagpush.outputs.new_tag }}"
+          echo "Dispatched Docker (release) for ${{ steps.tagpush.outputs.new_tag }}"


### PR DESCRIPTION
### Problem
Tags created by **Version tag from PR label** are pushed with `GITHUB_TOKEN`. GitHub **does not run** `on: push: tags` workflows for those pushes, so **Docker (release)** never started for e.g. **v0.9.0**.

### Fix
1. **`pr-label-version-tag.yml`** — add `actions: write`, write `new_tag` to outputs, then **`gh workflow run docker-release.yml -f tag=…`** using `github.token` (workflow_dispatch is allowed to start another workflow).
2. **`docker-release.yml`** — also trigger on **`release: types: [published]`** and take the tag from `github.event.release.tag_name` (backup if you ship via GitHub Releases).

### After merge — publish **v0.9.0** images now
**Actions → Docker (release) → Run workflow → tag:** `v0.9.0`

(Ensure `DOCKERHUB_*` secrets are set; GHCR uses `GH_TOKEN` or default token.)

### Repo settings
**Settings → Actions → General → Workflow permissions** should allow **Read and write** so `actions: write` works for dispatch.