### PR TITLE
feat: Zephyr environments (list/get/create/update) — v0.10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ The following environment variables are required:
 - `create_multiple_test_cases`: Create multiple test cases in Zephyr at once
 - `search_test_cases`: Search for test cases in a project
 - `get_test_case`: Get detailed information about a specific test case
+- `list_environments` / `get_environment` / `create_environment` / `update_environment`: List and manage Zephyr test environments per project
 
 ### Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **create_test_cycle** / **list_test_cycles** | Create and list test cycles. |
 | **list_folders** / **create_folder** | List and create folders (for organizing test cases or test cycles). Filter by folderType (TEST_CASE / TEST_CYCLE) and parentId for subfolders. |
 | **list_priorities** / **list_statuses** | List test case priorities and statuses (id and name). Use the returned ids when creating or updating test cases. Optional projectKey. |
+| **list_environments** / **get_environment** / **create_environment** / **update_environment** | List and manage test environments per project (`GET/POST/PUT /environments`). Use returned names with **create_test_cycle** / **update_test_cycle** (`environment`) and **create_test_execution** (`environmentName`). |
 | **list_projects** | List Zephyr-visible projects (id, key, name). Optional `limit`, `startAt` for pagination. Use for projectKey discovery. |
 | **list_test_executions_in_cycle** | List test cases and executions in a cycle. |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
@@ -176,6 +177,14 @@ create_folder({ projectKey: "ABC", name: "Subfolder", parentId: 12345 });
 list_priorities({ projectKey: "ABC" });   // or omit projectKey for all
 list_statuses({ projectKey: "ABC" });     // use returned id in create_test_case / update_test_case
 create_test_case({ projectKey: "ABC", name: "...", priority: "365033" });  // priority/status sent as { id } to API
+```
+
+**Environments**
+```ts
+list_environments({ projectKey: "ABC", limit: 50, startAt: 0 });
+get_environment({ environmentId: "101" });  // or key if your API returns one
+create_environment({ projectKey: "ABC", name: "Staging", description: "Pre-prod" });
+update_environment({ environmentId: "101", name: "Staging EU" });
 ```
 
 **Test cases and script types**
@@ -266,8 +275,8 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Get single test plan / test cycle** — `get_test_plan` and `get_test_cycle` fetch one plan or cycle by key or ID.
 - [x] **Folders** — `list_folders` and `create_folder` (filter by folderType, parentId for hierarchy).
 - [x] **Priorities and statuses** — `list_priorities` and `list_statuses` (id and name for create/update test case).
-- [ ] **Zephyr projects list** — List projects from Zephyr API for projectKey discovery.
-- [ ] **Environments** — List or manage environments for cycles.
+- [x] **Zephyr projects list** — `list_projects` (id, key, name; pagination).
+- [x] **Environments** — `list_environments`, `get_environment`, `create_environment`, `update_environment` (v0.10.0).
 - [ ] **Test case archive / delete** — Archive and delete test cases (per Zephyr docs).
 - [x] **Test steps as separate resource** — `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` (v0.7). Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER.
 - [x] **Remove test case from cycle** — `remove_test_case_from_cycle` calls `DELETE /testexecutions/{id}` (resolve via `list_test_executions_in_cycle` or pass `cycleKey` + `testCaseKey`). Official docs may not advertise this; some tenants return 404/405.

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -66,8 +66,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 9. **Environments**
 
-- **API:** Environment-related endpoints (list/create if available) for test cycles.
-- **Gap:** Cycles can be created with `environment` (string); no tool to list or manage environments. Harder to keep environment values consistent.
+- **API:** `GET /environments` (e.g. `projectKey`, pagination), `GET /environments/{id}`, `POST /environments`, `PUT /environments/{id}` ([path layout](https://support.smartbear.com/zephyr-scale-cloud/api-docs/) aligns with `environments` in Scale Cloud).
+- **MCP status:** Implemented (v0.10.0). `list_environments`, `get_environment`, `create_environment`, `update_environment`. Use returned **names** with `create_test_cycle` / `update_test_cycle` (`environment`) and `create_test_execution` (`environmentName`). **Update** loads the current environment then merges fields before PUT (some instances clear omitted fields on PUT).
 
 ### 10. **Test case archive / delete**
 
@@ -118,7 +118,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 6 | List/create folders | GET/POST folders | Implemented (v0.5) |
 | 7 | List Zephyr projects | GET projects | Implemented (`list_projects`, v0.8) |
 | 8 | List priorities/statuses | GET priorities, statuses | Implemented (v0.6) |
-| 9 | List/manage environments | GET (environments) | Not implemented |
+| 9 | List/manage environments | GET/POST/PUT environments | Implemented (`list_environments`, `get_environment`, `create_environment`, `update_environment`, v0.10.0) |
 | 10 | Archive/delete test case | Archive + delete (per docs) | Not implemented |
 | 11 | Test steps CRUD | testcases/{key}/teststeps | Implemented (v0.7) |
 | 12 | Remove test case from cycle | DELETE /testexecutions/{id} | Implemented (`remove_test_case_from_cycle`; API support varies by tenant) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.8.2",
+  "version": "0.10.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -12,6 +12,7 @@ import {
   ZephyrStatus,
   ZephyrTestStep,
   ZephyrProject,
+  ZephyrEnvironment,
 } from '../types/zephyr-types.js';
 
 export class ZephyrClient {
@@ -217,6 +218,67 @@ export class ZephyrClient {
     const response = await this.client.get('/statuses', { params });
     const list = response.data.values ?? response.data ?? [];
     return Array.isArray(list) ? list : [];
+  }
+
+  async getEnvironments(projectKey: string, limit = 50, startAt = 0): Promise<{
+    environments: ZephyrEnvironment[];
+    total: number;
+  }> {
+    const params = {
+      projectKey,
+      maxResults: limit,
+      startAt,
+    };
+    const response = await this.client.get('/environments', { params });
+    const environments = Array.isArray(response.data.values)
+      ? response.data.values
+      : Array.isArray(response.data)
+        ? response.data
+        : [];
+    return {
+      environments: environments as ZephyrEnvironment[],
+      total: response.data.total ?? environments.length,
+    };
+  }
+
+  async getEnvironment(environmentIdOrKey: string): Promise<ZephyrEnvironment> {
+    const id = encodeURIComponent(environmentIdOrKey);
+    const response = await this.client.get(`/environments/${id}`);
+    return response.data;
+  }
+
+  async createEnvironment(data: {
+    projectKey: string;
+    name: string;
+    description?: string;
+  }): Promise<ZephyrEnvironment> {
+    const payload: Record<string, string> = {
+      projectKey: data.projectKey,
+      name: data.name,
+    };
+    if (data.description !== undefined) {
+      payload.description = data.description;
+    }
+    const response = await this.client.post('/environments', payload);
+    return response.data;
+  }
+
+  /**
+   * PUT clears unspecified fields on some tenants; we GET first and merge like update_test_case.
+   */
+  async updateEnvironment(environmentIdOrKey: string, data: {
+    name?: string;
+    description?: string | null;
+  }): Promise<ZephyrEnvironment> {
+    const id = encodeURIComponent(environmentIdOrKey);
+    const existing = (await this.client.get(`/environments/${id}`)).data as Record<string, unknown>;
+    const payload = {
+      ...existing,
+      name: data.name !== undefined ? data.name : existing.name,
+      description: data.description !== undefined ? data.description : existing.description,
+    };
+    const response = await this.client.put(`/environments/${id}`, payload);
+    return response.data;
   }
 
   async addTestCasesToCycle(cycleKey: string, testCaseKeys: string[]): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { createTestCase, searchTestCases, getTestCase, updateTestCase, createMultipleTestCases } from './tools/test-cases.js';
 import { listTestSteps, createTestStep, updateTestStep, deleteTestStep } from './tools/test-steps.js';
 import { listFolders, createFolder } from './tools/folders.js';
+import { listEnvironments, getEnvironment, createEnvironment, updateEnvironment } from './tools/environments.js';
 import { listPriorities, listStatuses } from './tools/priorities-statuses.js';
 import { listProjects } from './tools/projects.js';
 import {
@@ -44,6 +45,10 @@ import {
   createFolderSchema,
   listPrioritiesSchema,
   listStatusesSchema,
+  listEnvironmentsSchema,
+  getEnvironmentSchema,
+  createEnvironmentSchema,
+  updateEnvironmentSchema,
   linkTestsToIssuesSchema,
   generateTestReportSchema,
   createTestCaseSchema,
@@ -74,6 +79,10 @@ import {
   CreateFolderInput,
   ListPrioritiesInput,
   ListStatusesInput,
+  ListEnvironmentsInput,
+  GetEnvironmentInput,
+  CreateEnvironmentInput,
+  UpdateEnvironmentInput,
   LinkTestsToIssuesInput,
   GenerateTestReportInput,
   CreateTestCaseInput,
@@ -90,7 +99,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.8.1',
+    version: '0.10.0',
   },
   {
     capabilities: {
@@ -381,6 +390,58 @@ const TOOLS = [
       properties: {
         projectKey: { type: 'string', description: 'JIRA project key (optional; if omitted returns all statuses)' },
       },
+    },
+  },
+  {
+    name: 'list_environments',
+    description:
+      'List test environments for a Jira project (Zephyr Scale). Use names when setting cycle environment or create_test_execution environmentName for consistency.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key' },
+        limit: { type: 'number', description: 'Max results (default: 50)' },
+        startAt: { type: 'number', description: 'Pagination offset (default: 0)' },
+      },
+      required: ['projectKey'],
+    },
+  },
+  {
+    name: 'get_environment',
+    description: 'Get a single test environment by numeric id or key (Zephyr Scale GET /environments/{id}).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        environmentId: { type: 'string', description: 'Environment id or key' },
+      },
+      required: ['environmentId'],
+    },
+  },
+  {
+    name: 'create_environment',
+    description: 'Create a test environment in a project (Zephyr Scale POST /environments).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key' },
+        name: { type: 'string', description: 'Environment name (e.g. Production, Staging)' },
+        description: { type: 'string', description: 'Optional description' },
+      },
+      required: ['projectKey', 'name'],
+    },
+  },
+  {
+    name: 'update_environment',
+    description:
+      'Update a test environment name and/or description. Fetches the current environment first then PUTs a full body (Zephyr clears omitted fields on some instances).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        environmentId: { type: 'string', description: 'Environment id or key' },
+        name: { type: 'string', description: 'New name (optional)' },
+        description: { type: 'string', description: 'New description; omit to keep, null to clear if API allows (optional)' },
+      },
+      required: ['environmentId'],
     },
   },
   {
@@ -875,6 +936,54 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await listStatuses(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_environments': {
+        const validatedArgs = validateInput<ListEnvironmentsInput>(listEnvironmentsSchema, args, 'list_environments');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await listEnvironments(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_environment': {
+        const validatedArgs = validateInput<GetEnvironmentInput>(getEnvironmentSchema, args, 'get_environment');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await getEnvironment(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'create_environment': {
+        const validatedArgs = validateInput<CreateEnvironmentInput>(createEnvironmentSchema, args, 'create_environment');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await createEnvironment(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_environment': {
+        const validatedArgs = validateInput<UpdateEnvironmentInput>(updateEnvironmentSchema, args, 'update_environment');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await updateEnvironment(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -1,0 +1,122 @@
+import { ZephyrClient } from '../clients/zephyr-client.js';
+import {
+  listEnvironmentsSchema,
+  getEnvironmentSchema,
+  createEnvironmentSchema,
+  updateEnvironmentSchema,
+  ListEnvironmentsInput,
+  GetEnvironmentInput,
+  CreateEnvironmentInput,
+  UpdateEnvironmentInput,
+} from '../utils/validation.js';
+
+let zephyrClient: ZephyrClient | null = null;
+
+const getZephyrClient = (): ZephyrClient => {
+  if (!zephyrClient) {
+    zephyrClient = new ZephyrClient();
+  }
+  return zephyrClient;
+};
+
+export const listEnvironments = async (input: ListEnvironmentsInput) => {
+  const validatedInput = listEnvironmentsSchema.parse(input);
+  try {
+    const result = await getZephyrClient().getEnvironments(
+      validatedInput.projectKey,
+      validatedInput.limit,
+      validatedInput.startAt
+    );
+    return {
+      success: true,
+      data: {
+        total: result.total,
+        environments: result.environments.map((e: any) => ({
+          id: e.id,
+          name: e.name,
+          description: e.description ?? null,
+          projectKey: e.projectKey,
+          self: e.self,
+        })),
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const getEnvironment = async (input: GetEnvironmentInput) => {
+  const validatedInput = getEnvironmentSchema.parse(input);
+  try {
+    const e = await getZephyrClient().getEnvironment(validatedInput.environmentId);
+    return {
+      success: true,
+      data: {
+        id: e.id,
+        name: e.name,
+        description: e.description ?? null,
+        projectKey: (e as any).projectKey,
+        self: e.self,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const createEnvironment = async (input: CreateEnvironmentInput) => {
+  const validatedInput = createEnvironmentSchema.parse(input);
+  try {
+    const e = await getZephyrClient().createEnvironment({
+      projectKey: validatedInput.projectKey,
+      name: validatedInput.name,
+      description: validatedInput.description,
+    });
+    return {
+      success: true,
+      data: {
+        id: e.id,
+        name: e.name,
+        description: e.description ?? null,
+        projectKey: (e as any).projectKey,
+        self: e.self,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const updateEnvironment = async (input: UpdateEnvironmentInput) => {
+  const validatedInput = updateEnvironmentSchema.parse(input);
+  try {
+    const e = await getZephyrClient().updateEnvironment(validatedInput.environmentId, {
+      name: validatedInput.name,
+      description: validatedInput.description,
+    });
+    return {
+      success: true,
+      data: {
+        id: e.id,
+        name: e.name,
+        description: e.description ?? null,
+        projectKey: (e as any).projectKey,
+        self: e.self,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -107,6 +107,16 @@ export interface ZephyrTestCase {
   };
 }
 
+/** Test environment (Zephyr Scale Cloud: GET/POST/PUT `/environments`). */
+export interface ZephyrEnvironment {
+  id: number;
+  name: string;
+  description?: string | null;
+  projectKey?: string;
+  project?: { id?: number; self?: string };
+  self?: string;
+}
+
 export interface ZephyrFolder {
   id: number;
   name: string;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -130,10 +130,41 @@ export const listStatusesSchema = z.object({
   projectKey: z.string().min(1).optional(),
 });
 
+export const listEnvironmentsSchema = z.object({
+  projectKey: z.string().min(1, 'Project key is required'),
+  limit: z.number().min(1).max(100).default(50),
+  startAt: z.number().min(0).default(0),
+});
+
+export const getEnvironmentSchema = z.object({
+  environmentId: z.string().min(1, 'Environment id or key is required'),
+});
+
+export const createEnvironmentSchema = z.object({
+  projectKey: z.string().min(1, 'Project key is required'),
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+});
+
+export const updateEnvironmentSchema = z
+  .object({
+    environmentId: z.string().min(1, 'Environment id or key is required'),
+    name: z.string().min(1).optional(),
+    description: z.string().nullable().optional(),
+  })
+  .refine(
+    data => data.name !== undefined || data.description !== undefined,
+    { message: 'At least one of name or description must be provided' }
+  );
+
 export type ListFoldersInput = z.infer<typeof listFoldersSchema>;
 export type CreateFolderInput = z.infer<typeof createFolderSchema>;
 export type ListPrioritiesInput = z.infer<typeof listPrioritiesSchema>;
 export type ListStatusesInput = z.infer<typeof listStatusesSchema>;
+export type ListEnvironmentsInput = z.infer<typeof listEnvironmentsSchema>;
+export type GetEnvironmentInput = z.infer<typeof getEnvironmentSchema>;
+export type CreateEnvironmentInput = z.infer<typeof createEnvironmentSchema>;
+export type UpdateEnvironmentInput = z.infer<typeof updateEnvironmentSchema>;
 
 export const createTestExecutionSchema = z.object({
   projectKey: z.string().min(1, 'Project key is required'),

--- a/tests/contract/zephyr-contract.test.ts
+++ b/tests/contract/zephyr-contract.test.ts
@@ -12,16 +12,25 @@
  *   - ZEPHYR_CONTRACT_CYCLE_KEY (e.g. MYPROJ-R1)
  *
  * Run: npm run test:contract (contract only) | npm run test (all) | npm run test:integration (integration mocked only)
+ *
+ * If JIRA and Zephyr credentials are not set, the whole suite is skipped so `npm test` still passes locally.
  */
 import { config } from 'dotenv';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ZephyrClient } from '../../src/clients/zephyr-client.js';
 
-describe('Zephyr API contract', () => {
+config();
+
+const hasContractCredentials =
+  Boolean(process.env.ZEPHYR_API_TOKEN?.trim()) &&
+  Boolean(process.env.JIRA_BASE_URL?.trim()) &&
+  Boolean(process.env.JIRA_USERNAME?.trim()) &&
+  Boolean(process.env.JIRA_API_TOKEN?.trim());
+
+describe.skipIf(!hasContractCredentials)('Zephyr API contract', () => {
   let client: ZephyrClient;
 
   beforeAll(() => {
-    config(); // reload .env so we use real credentials even if unit tests ran first
     client = new ZephyrClient();
   });
 
@@ -98,6 +107,22 @@ describe('Zephyr API contract', () => {
       // Single-cycle GET may omit executionSummary; list responses often include it.
       if ('executionSummary' in result && result.executionSummary != null) {
         expect(result.executionSummary).toHaveProperty('total');
+      }
+    }
+  );
+
+  it.skipIf(!process.env.ZEPHYR_CONTRACT_PROJECT_KEY)(
+    'GET /environments with projectKey returns list with total',
+    async () => {
+      const projectKey = process.env.ZEPHYR_CONTRACT_PROJECT_KEY!;
+      const result = await client.getEnvironments(projectKey, 20, 0);
+      expect(result).toHaveProperty('environments');
+      expect(result).toHaveProperty('total');
+      expect(Array.isArray(result.environments)).toBe(true);
+      expect(result.total).toBeGreaterThanOrEqual(0);
+      for (const env of result.environments) {
+        expect(env).toHaveProperty('id');
+        expect(env).toHaveProperty('name');
       }
     }
   );

--- a/tests/fixtures/zephyr/environment-create.json
+++ b/tests/fixtures/zephyr/environment-create.json
@@ -1,0 +1,7 @@
+{
+  "id": 103,
+  "name": "QA",
+  "description": "QA stack",
+  "projectKey": "PROJ",
+  "self": "https://api.zephyrscale.smartbear.com/v2/environments/103"
+}

--- a/tests/fixtures/zephyr/environment-get.json
+++ b/tests/fixtures/zephyr/environment-get.json
@@ -1,0 +1,7 @@
+{
+  "id": 101,
+  "name": "Production",
+  "description": "Live system",
+  "projectKey": "PROJ",
+  "self": "https://api.zephyrscale.smartbear.com/v2/environments/101"
+}

--- a/tests/fixtures/zephyr/environments-list.json
+++ b/tests/fixtures/zephyr/environments-list.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    { "id": 101, "name": "Production", "description": "Live", "projectKey": "PROJ", "self": "https://api.zephyrscale.smartbear.com/v2/environments/101" },
+    { "id": 102, "name": "Staging", "description": null, "projectKey": "PROJ", "self": "https://api.zephyrscale.smartbear.com/v2/environments/102" }
+  ],
+  "total": 2
+}

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -178,6 +178,74 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('getEnvironments', () => {
+    it('sends GET /v2/environments with projectKey and pagination', async () => {
+      const body = loadFixture('environments-list.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/environments`)
+        .query({ projectKey: 'PROJ', maxResults: 50, startAt: 0 })
+        .reply(200, body);
+
+      const result = await client.getEnvironments('PROJ');
+
+      expect(result.environments).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.environments[0].name).toBe('Production');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getEnvironment', () => {
+    it('sends GET /v2/environments/{id}', async () => {
+      const body = loadFixture('environment-get.json');
+      const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/environments/101`).reply(200, body);
+
+      const result = await client.getEnvironment('101');
+
+      expect(result.id).toBe(101);
+      expect(result.name).toBe('Production');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('createEnvironment', () => {
+    it('sends POST /v2/environments with projectKey and name', async () => {
+      const body = loadFixture('environment-create.json');
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/environments`, (reqBody: Record<string, unknown>) => {
+          return reqBody.projectKey === 'PROJ' && reqBody.name === 'QA' && reqBody.description === 'QA stack';
+        })
+        .reply(200, body);
+
+      const result = await client.createEnvironment({
+        projectKey: 'PROJ',
+        name: 'QA',
+        description: 'QA stack',
+      });
+
+      expect(result.id).toBe(103);
+      expect(result.name).toBe('QA');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('updateEnvironment', () => {
+    it('GETs then PUTs merged environment body', async () => {
+      const existing = loadFixture('environment-get.json') as Record<string, unknown>;
+      const updated = { ...existing, name: 'Production EU' };
+      const getScope = nock(ZEPHYR_ORIGIN).get(`${V2}/environments/101`).reply(200, existing);
+      const putScope = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/environments/101`, (reqBody: Record<string, unknown>) => reqBody.name === 'Production EU')
+        .reply(200, updated);
+
+      const result = await client.updateEnvironment('101', { name: 'Production EU' });
+
+      expect(result.name).toBe('Production EU');
+      expect(getScope.isDone()).toBe(true);
+      expect(putScope.isDone()).toBe(true);
+    });
+  });
+
   describe('searchTestCases', () => {
     it('sends GET /v2/testcases/search with projectKey and maxResults', async () => {
       const body = loadFixture('testcases-search.json');


### PR DESCRIPTION
### Summary
Release **v0.10.0**: expose Zephyr Scale Cloud **environments** so cycles and executions can use consistent environment names from the API instead of free-typed strings only.

### MCP tools
| Tool | API |
|------|-----|
| `list_environments` | `GET /environments` (`projectKey`, `maxResults`, `startAt`) |
| `get_environment` | `GET /environments/{id}` |
| `create_environment` | `POST /environments` |
| `update_environment` | `GET` + merged `PUT /environments/{id}` (avoids clearing fields on PUT where the API requires a full body) |

### Also
- **Tests:** nock integration tests for all four client methods; contract test for `GET /environments` when `ZEPHYR_CONTRACT_PROJECT_KEY` is set.
- **DX:** Contract suite is **skipped** when JIRA/Zephyr credentials are missing so `npm test` passes locally without `.env`.
- **Docs:** README (tools table, examples, roadmap), `CLAUDE.md`, `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md`.
- **Version:** `package.json` and MCP server `version` → **0.10.0**.

### Release note
Tag **v0.10.0** after merge; Docker/release workflows can follow your usual label or manual dispatch flow.