### PR TITLE
fix: dotenv quiet for MCP stdio (v0.10.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,5 +307,6 @@ MIT — see [LICENSE](LICENSE).
 
 ## Support
 
+- **Cursor + Docker:** The MCP log may show pull progress as `[error]` because Docker prints that to **stderr** while the UI treats stderr as errors. That is normal. A real problem is a **JSON parse** / “not valid JSON” line on startup: the MCP protocol requires a clean **stdout** stream. **v0.10.1+** loads dotenv with `quiet: true` so tip output does not break stdio (fixed from v0.10.0).
 - Open a [GitHub issue](https://github.com/miklosbagi/jira-zephyr-mcp/issues) with details and logs (no secrets).
 - Upstream: [leorosignoli/jira-zephyr-mcp](https://github.com/leorosignoli/jira-zephyr-mcp).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.10.0',
+    version: '0.10.1',
   },
   {
     capabilities: {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,8 @@
 import { config } from 'dotenv';
 import { z } from 'zod';
 
-config();
+// MCP stdio transport: stdout must be JSON-RPC only. dotenv v17+ prints tips to stdout by default.
+config({ quiet: true });
 
 const configSchema = z.object({
   JIRA_BASE_URL: z.string().url(),

--- a/tests/contract/zephyr-contract.test.ts
+++ b/tests/contract/zephyr-contract.test.ts
@@ -19,7 +19,7 @@ import { config } from 'dotenv';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ZephyrClient } from '../../src/clients/zephyr-client.js';
 
-config();
+config({ quiet: true });
 
 const hasContractCredentials =
   Boolean(process.env.ZEPHYR_API_TOKEN?.trim()) &&


### PR DESCRIPTION
### Problem
Cursor (and other MCP hosts) failed to initialize the server with:

`Unexpected token 'd', "[dotenv@17."... is not valid JSON`

**MCP over stdio** requires **stdout to contain only JSON-RPC**. `dotenv` v17+ prints informational lines (e.g. `[dotenv@17.3.1] injecting env …`) to **stdout** by default, which corrupts the stream.

### Fix
- `config({ quiet: true })` in `src/utils/config.ts` and contract tests.

### Why Docker pull lines look like “errors”
Docker writes image pull progress to **stderr**. Many UIs (including Cursor’s MCP log) classify stderr as `[error]` even when the pull succeeds. That is **cosmetic**; not something the image can change.

### Release
- **v0.10.1** — `package.json` + MCP server metadata.

### Docs
- README **Support**: short note on stderr vs real JSON parse failures.