### PR TITLE
ci(docker-pr): build when PR marked ready, skip drafts

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -16,6 +16,7 @@
 #
 # Draft PRs: no build (saves registry churn). When you mark the PR ready, `ready_for_review`
 # runs a build without requiring a new commit (synchronize alone does not fire on draft→ready).
+# Pushes while draft still trigger the workflow run, but the Docker job is skipped (check Actions).
 #
 # Images are built for linux/amd64 and linux/arm64 (Apple Silicon) via QEMU + buildx.
 name: Docker (PR)


### PR DESCRIPTION
### Problem
- Turning a **draft PR into ready** does **not** emit `synchronize`, so **Docker (PR)** never ran until the next push — no new dev image after “Mark ready”.
- You asked to **skip Docker builds for draft PRs** to avoid churn.

### Changes
| Change | Why |
|--------|-----|
| `types: ready_for_review` | Build once when the PR leaves draft / becomes reviewable **without** an extra empty commit. |
| `if: … && github.event.pull_request.draft == false` | No push to Docker Hub / GHCR while the PR is draft. |
| `concurrency` per PR + `cancel-in-progress: true` | New pushes cancel an in-flight build so the **latest** commit is what gets published (avoids out-of-order finishes). |

### Still triggers on
`opened` / `synchronize` / `reopened` (unchanged), but only when **not draft**.

### Note
If the PR is **not** draft, every push to the head branch still fires `synchronize` and should run this workflow — if something still skips, check the Actions tab for a **skipped** job (draft) vs. failed login/secrets.