### PR TITLE
feat: archive / unarchive / delete test case (v0.11.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ The following environment variables are required:
 - `create_multiple_test_cases`: Create multiple test cases in Zephyr at once
 - `search_test_cases`: Search for test cases in a project
 - `get_test_case`: Get detailed information about a specific test case
+- `archive_test_case` / `unarchive_test_case` / `delete_test_case`: Archive, unarchive, or delete a test case (API support varies by tenant)
 - `list_environments` / `get_environment` / `create_environment` / `update_environment`: List and manage Zephyr test environments per project
 
 ### Setup Instructions

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
 | **remove_test_case_from_cycle** | Remove a test case from a cycle by deleting its test execution (`DELETE /testexecutions/{id}`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve it. If the public API returns 404/405 on your instance, use the Zephyr UI or contact SmartBear. |
 | **create_test_case** / **search_test_cases** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
+| **archive_test_case** / **unarchive_test_case** / **delete_test_case** | Archive via PUT (`archived` flag), unarchive, or DELETE. **API support varies** — some instances reject `archived` or DELETE; see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md). |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
 | **execute_test** | Update test execution status (PASS/FAIL/WIP/BLOCKED). |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
@@ -196,6 +197,9 @@ search_test_cases({ projectKey: "ABC", query: "login", limit: 20 });
 get_test_case({ testCaseId: "ABC-T123" });
 update_test_case({ testCaseId: "ABC-T123", customFields: { "Created On": "2026-03-11" } });
 create_multiple_test_cases({ testCases: [...], continueOnError: true });
+archive_test_case({ testCaseKey: "ABC-T999" });
+unarchive_test_case({ testCaseKey: "ABC-T999" });
+delete_test_case({ testCaseKey: "ABC-T999" });  // may 404/405; remove from cycles first
 ```
 
 **Test steps (step-by-step test cases)**
@@ -277,7 +281,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Priorities and statuses** — `list_priorities` and `list_statuses` (id and name for create/update test case).
 - [x] **Zephyr projects list** — `list_projects` (id, key, name; pagination).
 - [x] **Environments** — `list_environments`, `get_environment`, `create_environment`, `update_environment` (v0.10.0).
-- [ ] **Test case archive / delete** — Archive and delete test cases (per Zephyr docs).
+- [x] **Test case archive / delete** — `archive_test_case`, `unarchive_test_case`, `delete_test_case` (v0.11.0; API caveats in gaps doc).
 - [x] **Test steps as separate resource** — `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` (v0.7). Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER.
 - [x] **Remove test case from cycle** — `remove_test_case_from_cycle` calls `DELETE /testexecutions/{id}` (resolve via `list_test_executions_in_cycle` or pass `cycleKey` + `testCaseKey`). Official docs may not advertise this; some tenants return 404/405.
 - [ ] **Update test plan / test cycle** — PUT for plans and cycles (rename, dates, status).
@@ -287,7 +291,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 
 ## Contributing
 
-Fork, create a feature branch, make changes, and open a pull request.
+Fork, create a feature branch, make changes, and open a **draft** pull request until it is ready for review.
 
 ---
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -71,9 +71,9 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 10. **Test case archive / delete**
 
-- **API:** Archive and/or delete test cases (exact endpoints to be confirmed in API docs; deletion may be async or batch in UI).
-- **Gap:** No archive or delete. Only create, read, update, and link are supported.
-- **Ref:** [Deleting test cases (UI)](https://support.smartbear.com/zephyr-scale-cloud/docs/en/test-cases/deleting-test-cases.html)
+- **API (used by MCP):** `PUT /testcases/{key}` with a full body including **`archived: true|false`** (after `GET` merge, same pattern as `update_test_case`). `DELETE /testcases/{key}` for permanent removal.
+- **MCP status:** Implemented (v0.11.0): `archive_test_case`, `unarchive_test_case`, `delete_test_case`.
+- **Caveat:** SmartBear’s public reference and community threads often state that **delete/archive are UI-first** or not guaranteed on the Scale Cloud v2 surface. **`archived` on PUT** may be ignored or rejected (400) on some tenants. **`DELETE`** may return **404/405**. Prefer **`archive_test_case`** when supported; use **[Deleting test cases (UI)](https://support.smartbear.com/zephyr-scale-cloud/docs/en/test-cases/deleting-test-cases.html)** for permanent delete if the API refuses (dependencies must be removed first).
 
 ### 11. **Test steps as a separate resource**
 
@@ -119,7 +119,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 7 | List Zephyr projects | GET projects | Implemented (`list_projects`, v0.8) |
 | 8 | List priorities/statuses | GET priorities, statuses | Implemented (v0.6) |
 | 9 | List/manage environments | GET/POST/PUT environments | Implemented (`list_environments`, `get_environment`, `create_environment`, `update_environment`, v0.10.0) |
-| 10 | Archive/delete test case | Archive + delete (per docs) | Not implemented |
+| 10 | Archive/delete test case | PUT archived; DELETE testcases/{key} | Implemented (`archive_test_case`, `unarchive_test_case`, `delete_test_case`, v0.11.0); API support varies by tenant |
 | 11 | Test steps CRUD | testcases/{key}/teststeps | Implemented (v0.7) |
 | 12 | Remove test case from cycle | DELETE /testexecutions/{id} | Implemented (`remove_test_case_from_cycle`; API support varies by tenant) |
 | 13 | Update test plan / test cycle | PUT testplans, testcycles | Not implemented |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -809,6 +809,44 @@ export class ZephyrClient {
     return response.data;
   }
 
+  /**
+   * Set test case archived flag via PUT /testcases/{key} with full body.
+   * Official docs vary; some tenants accept `archived` on the entity, others return 400.
+   */
+  async setTestCaseArchived(testCaseKey: string, archived: boolean): Promise<ZephyrTestCase> {
+    const existing = await this.getTestCase(testCaseKey);
+    const projectId = existing.project?.id ?? (existing as any).projectKey;
+    const priorityId = existing.priority?.id ?? (existing as any).priority;
+    const statusId = existing.status?.id ?? (existing as any).status;
+    const payload: Record<string, any> = {
+      id: existing.id,
+      key: existing.key,
+      name: existing.name,
+      project: { id: projectId },
+      priority: { id: priorityId },
+      status: { id: statusId },
+      objective: existing.objective,
+      precondition: existing.precondition,
+      estimatedTime: existing.estimatedTime,
+      folderId: existing.folder?.id,
+      labels: existing.labels ?? [],
+      componentId: existing.component?.id,
+      customFields: { ...(existing.customFields ?? {}) },
+      archived,
+    };
+    const response = await this.client.put(`/testcases/${testCaseKey}`, payload);
+    return response.data;
+  }
+
+  /**
+   * Permanently delete a test case (DELETE /testcases/{key}).
+   * Not all instances document or enable this; you may need to archive in the UI first.
+   */
+  async deleteTestCase(testCaseKey: string): Promise<void> {
+    const id = encodeURIComponent(testCaseKey);
+    await this.client.delete(`/testcases/${id}`);
+  }
+
   async createMultipleTestCases(testCases: Array<{
     projectKey: string;
     name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,16 @@ import {
   linkTestsToIssues,
   generateTestReport,
 } from './tools/test-execution.js';
-import { createTestCase, searchTestCases, getTestCase, updateTestCase, createMultipleTestCases } from './tools/test-cases.js';
+import {
+  createTestCase,
+  searchTestCases,
+  getTestCase,
+  updateTestCase,
+  archiveTestCase,
+  unarchiveTestCase,
+  deleteTestCase,
+  createMultipleTestCases,
+} from './tools/test-cases.js';
 import { listTestSteps, createTestStep, updateTestStep, deleteTestStep } from './tools/test-steps.js';
 import { listFolders, createFolder } from './tools/folders.js';
 import { listEnvironments, getEnvironment, createEnvironment, updateEnvironment } from './tools/environments.js';
@@ -55,6 +64,9 @@ import {
   searchTestCasesSchema,
   getTestCaseSchema,
   updateTestCaseSchema,
+  archiveTestCaseSchema,
+  unarchiveTestCaseSchema,
+  deleteTestCaseSchema,
   createMultipleTestCasesSchema,
   listTestStepsSchema,
   createTestStepSchema,
@@ -89,6 +101,9 @@ import {
   SearchTestCasesInput,
   GetTestCaseInput,
   UpdateTestCaseInput,
+  ArchiveTestCaseInput,
+  UnarchiveTestCaseInput,
+  DeleteTestCaseInput,
   CreateMultipleTestCasesInput,
   ListTestStepsInput,
   CreateTestStepInput,
@@ -99,7 +114,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.10.2',
+    version: '0.11.0',
   },
   {
     capabilities: {
@@ -608,6 +623,42 @@ const TOOLS = [
     },
   },
   {
+    name: 'archive_test_case',
+    description:
+      'Archive a test case (PUT /testcases/{key} with archived: true after GET merge). Zephyr often requires archiving before permanent delete in the UI; API support for `archived` varies by tenant — errors may mean your instance expects status changes or UI-only archive.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key (e.g. PROJ-T123)' },
+      },
+      required: ['testCaseKey'],
+    },
+  },
+  {
+    name: 'unarchive_test_case',
+    description:
+      'Restore an archived test case (PUT with archived: false). Same API caveats as archive_test_case.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key (e.g. PROJ-T123)' },
+      },
+      required: ['testCaseKey'],
+    },
+  },
+  {
+    name: 'delete_test_case',
+    description:
+      'Permanently delete a test case (DELETE /testcases/{key}). Often undocumented or disabled on public Scale API; may return 404/405. Remove from cycles and dependencies first (see Zephyr docs). Prefer archive_test_case + UI delete if API delete fails.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        testCaseKey: { type: 'string', description: 'Test case key (e.g. PROJ-T123)' },
+      },
+      required: ['testCaseKey'],
+    },
+  },
+  {
     name: 'create_multiple_test_cases',
     description: 'Create multiple test cases in Zephyr at once',
     inputSchema: {
@@ -1032,6 +1083,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await updateTestCase(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'archive_test_case': {
+        const validatedArgs = validateInput<ArchiveTestCaseInput>(archiveTestCaseSchema, args, 'archive_test_case');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await archiveTestCase(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'unarchive_test_case': {
+        const validatedArgs = validateInput<UnarchiveTestCaseInput>(unarchiveTestCaseSchema, args, 'unarchive_test_case');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await unarchiveTestCase(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'delete_test_case': {
+        const validatedArgs = validateInput<DeleteTestCaseInput>(deleteTestCaseSchema, args, 'delete_test_case');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await deleteTestCase(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-cases.ts
+++ b/src/tools/test-cases.ts
@@ -5,10 +5,16 @@ import {
   searchTestCasesSchema,
   createMultipleTestCasesSchema,
   updateTestCaseSchema,
+  archiveTestCaseSchema,
+  unarchiveTestCaseSchema,
+  deleteTestCaseSchema,
   CreateTestCaseInput,
   SearchTestCasesInput,
   CreateMultipleTestCasesInput,
   UpdateTestCaseInput,
+  ArchiveTestCaseInput,
+  UnarchiveTestCaseInput,
+  DeleteTestCaseInput,
 } from '../utils/validation.js';
 
 let zephyrClient: ZephyrClient | null = null;
@@ -167,6 +173,64 @@ export const updateTestCase = async (input: UpdateTestCaseInput) => {
           self: `${getZephyrBaseUrl().replace(/\/$/, '')}/testcases/${testCase.key}`,
         },
       },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const archiveTestCase = async (input: ArchiveTestCaseInput) => {
+  const validatedInput = archiveTestCaseSchema.parse(input);
+  try {
+    const testCase = await getZephyrClient().setTestCaseArchived(validatedInput.testCaseKey, true);
+    return {
+      success: true,
+      data: {
+        id: testCase.id,
+        key: testCase.key,
+        name: testCase.name,
+        archived: (testCase as any).archived ?? true,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const unarchiveTestCase = async (input: UnarchiveTestCaseInput) => {
+  const validatedInput = unarchiveTestCaseSchema.parse(input);
+  try {
+    const testCase = await getZephyrClient().setTestCaseArchived(validatedInput.testCaseKey, false);
+    return {
+      success: true,
+      data: {
+        id: testCase.id,
+        key: testCase.key,
+        name: testCase.name,
+        archived: (testCase as any).archived ?? false,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const deleteTestCase = async (input: DeleteTestCaseInput) => {
+  const validatedInput = deleteTestCaseSchema.parse(input);
+  try {
+    await getZephyrClient().deleteTestCase(validatedInput.testCaseKey);
+    return {
+      success: true,
+      data: { testCaseKey: validatedInput.testCaseKey, deleted: true },
     };
   } catch (error: any) {
     return {

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -94,6 +94,8 @@ export interface ZephyrTestCase {
     self: string;
   };
   customFields?: Record<string, any>;
+  /** Present on some GET responses when the test case is archived. */
+  archived?: boolean;
   links?: {
     self: string;
     issues?: Array<{

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -220,6 +220,18 @@ export const getTestCaseSchema = z.object({
   testCaseId: z.string().min(1, 'Test case ID is required'),
 });
 
+export const archiveTestCaseSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+});
+
+export const unarchiveTestCaseSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+});
+
+export const deleteTestCaseSchema = z.object({
+  testCaseKey: z.string().min(1, 'Test case key is required'),
+});
+
 export const updateTestCaseSchema = z.object({
   testCaseId: z.string().min(1, 'Test case ID or key is required'),
   name: z.string().min(1).optional(),
@@ -305,6 +317,9 @@ export type GenerateTestReportInput = z.infer<typeof generateTestReportSchema>;
 export type CreateTestCaseInput = z.infer<typeof createTestCaseSchema>;
 export type SearchTestCasesInput = z.infer<typeof searchTestCasesSchema>;
 export type GetTestCaseInput = z.infer<typeof getTestCaseSchema>;
+export type ArchiveTestCaseInput = z.infer<typeof archiveTestCaseSchema>;
+export type UnarchiveTestCaseInput = z.infer<typeof unarchiveTestCaseSchema>;
+export type DeleteTestCaseInput = z.infer<typeof deleteTestCaseSchema>;
 export type UpdateTestCaseInput = z.infer<typeof updateTestCaseSchema>;
 export type CreateMultipleTestCasesInput = z.infer<typeof createMultipleTestCasesSchema>;
 export type ListTestStepsInput = z.infer<typeof listTestStepsSchema>;

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -279,6 +279,48 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('setTestCaseArchived', () => {
+    it('GETs test case then PUTs with archived true', async () => {
+      const body = loadFixture('testcase-get.json') as Record<string, unknown>;
+      const updated = { ...body, archived: true };
+      const getScope = nock(ZEPHYR_ORIGIN).get(`${V2}/testcases/PROJ-T1`).reply(200, body);
+      const putScope = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testcases/PROJ-T1`, (reqBody: Record<string, unknown>) => reqBody.archived === true)
+        .reply(200, updated);
+
+      const result = await client.setTestCaseArchived('PROJ-T1', true);
+
+      expect(result.archived).toBe(true);
+      expect(getScope.isDone()).toBe(true);
+      expect(putScope.isDone()).toBe(true);
+    });
+
+    it('PUTs with archived false for unarchive', async () => {
+      const body = { ...loadFixture('testcase-get.json') as Record<string, unknown>, archived: true };
+      const updated = { ...body, archived: false };
+      const getScope = nock(ZEPHYR_ORIGIN).get(`${V2}/testcases/PROJ-T1`).reply(200, body);
+      const putScope = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testcases/PROJ-T1`, (reqBody: Record<string, unknown>) => reqBody.archived === false)
+        .reply(200, updated);
+
+      const result = await client.setTestCaseArchived('PROJ-T1', false);
+
+      expect(result.archived).toBe(false);
+      expect(getScope.isDone()).toBe(true);
+      expect(putScope.isDone()).toBe(true);
+    });
+  });
+
+  describe('deleteTestCase', () => {
+    it('sends DELETE /v2/testcases/{key}', async () => {
+      const scope = nock(ZEPHYR_ORIGIN).delete(`${V2}/testcases/PROJ-T1`).reply(204);
+
+      await client.deleteTestCase('PROJ-T1');
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
   describe('createTestCase', () => {
     it('sends POST /v2/testcases with expected body and returns created case', async () => {
       const body = loadFixture('testcase-create.json');


### PR DESCRIPTION
### Summary
Adds **archive_test_case**, **unarchive_test_case**, and **delete_test_case** for Zephyr Scale Cloud v2:

| Tool | API |
|------|-----|
| archive_test_case | GET /testcases/{key} then PUT full body with archived: true |
| unarchive_test_case | Same with archived: false |
| delete_test_case | DELETE /testcases/{key} |

### Caveats
Public docs and community threads often treat archive/delete as UI-first. Some tenants reject **archived** on PUT or return 404/405 on DELETE. Tools return API errors via success: false.

### Version & docs
- **0.11.0** in package.json and MCP server metadata
- README, CLAUDE.md, ZEPHYR-SCALE-CLOUD-API-GAPS.md updated
- README Contributing: open PRs as **draft** until ready
- Nock tests for client methods

### Before merge
Validate against your Zephyr instance (EU/US); tag v0.11.0 / Docker when satisfied.