### PR TITLE
ci: add CodeQL workflow and README badge (into PR #47 branch)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+# Required for branch protection rules that require "Code scanning" / CodeQL results.
+# Without this workflow, merges stay blocked on "Code scanning is waiting for results from CodeQL".
+#
+# Ref: https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '32 5 * * 1'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (JavaScript/TypeScript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An [MCP](https://modelcontextprotocol.io/) server for JIRA and **Zephyr Scale** 
 **Running it:** Use the published Docker image—no clone or build. Docker pulls the image when needed; you add a small config block to your AI tool (Cursor, Claude, Gemini, Windsurf, etc.). Cloning and building from source is for **developers and contributors** only.
 
 [![Integration tests](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/test.yml) · Integration (PR/push)  
+[![CodeQL](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/codeql.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/codeql.yml) · Code scanning (PR/push to `main`)  
 [![Zephyr contract](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml) · Zephyr contract (daily 6am CET / on demand).
 
 [![Docker Pulls](https://badgen.net/docker/pulls/miklosbagi/jira-zephyr-mcp?icon=docker&label=Docker%20Pulls)](https://hub.docker.com/r/miklosbagi/jira-zephyr-mcp/)


### PR DESCRIPTION
Adds `.github/workflows/codeql.yml` and the CodeQL badge in `README.md` (commit `0a074c0`).

Direct push to `feat/test-case-archive-delete` is blocked by repository rules (“Changes must be made through a pull request”); this PR lands the same changes on that branch so **#47** includes them after merge.