### PR TITLE
release: v0.11.1 distroless Docker runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,7 @@ The following environment variables are required:
 - `npm run build`: Build the project
 - `npm run typecheck`: Check TypeScript types
 - `npm run lint`: Lint the code
+
+### Docker releases
+
+Published images (**v0.11.1+**): final stage is **`gcr.io/distroless/nodejs22-debian13:nonroot`** (Node 22 only, no `npm`/shell). Build stage is **`node:22-bookworm-slim`** with `npm ci`, `npm run build`, and `npm prune --omit=dev` before copying `node_modules` + `dist/` into distroless. **v0.11.0** and earlier used `node:22-bookworm-slim` for runtime too.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-# Multi-stage: smaller image, no devDependencies, slimmer OS base (fewer packages for Docker Scout).
-# Final stage runs as non-root.
+# Multi-stage: full toolchain only in builder. Runtime uses Google's distroless Node image
+# (no npm, no shell, minimal OS) so scanners do not flag the bundled npm dependency tree
+# (tar, minimatch, glob, etc.) that ships with official node images but is unused at runtime.
+#
+# Final stage runs as nonroot (distroless :nonroot).
+# Ref: https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md
 
 FROM node:22-bookworm-slim AS builder
 WORKDIR /app
+
+# Debian security updates in build stage only (keeps builder current; not shipped in final image).
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run build
+RUN npm run build \
+  && npm prune --omit=dev
 
-FROM node:22-bookworm-slim AS production
+FROM gcr.io/distroless/nodejs22-debian13:nonroot
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -19,17 +29,7 @@ LABEL org.opencontainers.image.title="jira-zephyr-mcp" \
   org.opencontainers.image.description="MCP server for Jira and Zephyr Scale" \
   org.opencontainers.image.source="https://github.com/miklosbagi/jira-zephyr-mcp"
 
-# Apply Debian security updates at build time (reduces reported OS CVEs vs stale layer cache).
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder --chown=nonroot:nonroot /app/node_modules ./node_modules
+COPY --from=builder --chown=nonroot:nonroot /app/dist ./dist
 
-COPY package*.json ./
-RUN npm ci --omit=dev && npm cache clean --force
-
-COPY --from=builder /app/dist ./dist
-
-RUN chown -R node:node /app
-USER node
-
-CMD ["node", "dist/index.js"]
+CMD ["dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Fork, create a feature branch, make changes, and open a **draft** pull request u
 
 ## Security
 
-- **Docker image:** Multi-stage build on **`node:22-bookworm-slim`**, **production dependencies only** in the final image (no dev tooling), **`apt-get upgrade`** during build for Debian security fixes, and the process runs as the **`node`** user (not root). This reduces what [Docker Scout](https://docs.docker.com/scout/) and similar scanners flag versus a single-stage `node:22` image that retained `npm ci` devDependencies.
+- **Docker image (v0.11.1+):** **Build** stage uses **`node:22-bookworm-slim`** with **`apt-get upgrade`** (toolchain only). **Runtime** uses Google’s **[distroless](https://github.com/GoogleContainerTools/distroless) Node 22** (`gcr.io/distroless/nodejs22-debian13:nonroot`): **no bundled `npm`**, no shell, minimal OS, **`nonroot`** user. Only **`npm prune --omit=dev`**’d **`node_modules`** plus **`dist/`** are copied in—so [Docker Scout](https://docs.docker.com/scout/) and similar tools see far fewer findings from **`npm`’s own dependency tree** (`tar`, `minimatch`, `glob`, …) that ship in official `node` images but are unused at runtime. **v0.11.0** and earlier images used `node:22-bookworm-slim` for both stages.
 - Do not commit API tokens or credentials.
 - Use environment variables for all secrets.
 - Rotate tokens periodically and restrict JIRA/Zephyr access as needed.
@@ -312,6 +312,6 @@ MIT — see [LICENSE](LICENSE).
 
 ## Support
 
-- **Cursor + Docker:** The MCP log may show pull progress as `[error]` because Docker prints that to **stderr** while the UI treats stderr as errors. That is normal. A real problem is a **JSON parse** / “not valid JSON” line on startup: the MCP protocol requires a clean **stdout** stream. **v0.10.2+** loads dotenv with `quiet: true` so tip output does not break stdio, and hardens the published image for fewer reported CVEs (see [Security](#security)).
+- **Cursor + Docker:** The MCP log may show pull progress as `[error]` because Docker prints that to **stderr** while the UI treats stderr as errors. That is normal. A real problem is a **JSON parse** / “not valid JSON” line on startup: the MCP protocol requires a clean **stdout** stream. **v0.10.2+** loads dotenv with `quiet: true` so tip output does not break stdio. **v0.11.1+** published images use a **distroless** runtime (see [Security](#security)).
 - Open a [GitHub issue](https://github.com/miklosbagi/jira-zephyr-mcp/issues) with details and logs (no secrets).
 - Upstream: [leorosignoli/jira-zephyr-mcp](https://github.com/leorosignoli/jira-zephyr-mcp).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.8.2",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-zephyr-mcp",
-      "version": "0.8.2",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.11.0',
+    version: '0.11.1',
   },
   {
     capabilities: {


### PR DESCRIPTION
## v0.11.1 — Distroless Docker runtime

### Summary
- **Runtime image** switches from `node:22-bookworm-slim` to **`gcr.io/distroless/nodejs22-debian13:nonroot`** so the published image does **not** ship bundled **`npm`** (and its transitive `tar` / `minimatch` / `glob` tree), which should greatly reduce Docker Scout noise unrelated to the app.
- **Build stage:** `node:22-bookworm-slim`, `apt-get upgrade`, `npm ci`, `npm run build`, `npm prune --omit=dev`, then copy `node_modules` + `dist/` only.

### Version
- **0.11.1** in `package.json`, `package-lock.json`, and MCP `server.version` in `src/index.ts`.

### Docs
- **README** (Security, Support) and **CLAUDE.md** (Docker releases).

### After merge
- Tag **`v0.11.1`** (or run **Docker (release)**) and rescan the new image on Docker Hub / Scout.

### Notes
- Distroless final image has no shell; `CMD ["dist/index.js"]` uses the image `node` entrypoint.