### PR TITLE
v0.13.0: update_test_cycle extensions + update_test_plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,12 @@ The following environment variables are required:
 - `read_jira_issue`: Read JIRA issue details and metadata
 - `create_test_plan`: Create a new test plan in Zephyr
 - `list_test_plans`: List existing test plans
+- `get_test_plan`: Get one test plan by key or id
+- `update_test_plan`: Update a test plan (GET-merge-PUT; not in public OpenAPI — may 404/405 on some tenants)
 - `create_test_cycle`: Create a new test execution cycle
 - `list_test_cycles`: List existing test cycles with execution status
+- `get_test_cycle`: Get one test cycle by key or id
+- `update_test_cycle`: Update a test cycle (`PUT /testcycles/{key}`; GET-merge-PUT, including status, version, owner, custom fields)
 - `execute_test`: Update test execution results
 - `get_test_execution_status`: Get test execution progress and statistics
 - `remove_test_case_from_cycle`: Remove a test case from a cycle (delete test execution by id or cycle + case key)

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | Tool | Description |
 |------|-------------|
 | **read_jira_issue** | Get JIRA issue details (optional fields). |
-| **create_test_plan** / **list_test_plans** | Create and list test plans. |
-| **create_test_cycle** / **list_test_cycles** | Create and list test cycles. |
+| **create_test_plan** / **list_test_plans** / **get_test_plan** / **update_test_plan** | Test plans: create, list, get one; **update** uses GET-merge-PUT (not in the public OpenAPI; some tenants return 404/405 — see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md)). |
+| **create_test_cycle** / **list_test_cycles** / **get_test_cycle** / **update_test_cycle** | Test cycles: create, list, get one; **update** uses **`PUT /testcycles/{key}`** with GET-merge-PUT (name, description, folder, environment, dates, status, Jira version, owner, custom fields). |
 | **list_folders** / **create_folder** | List and create folders (for organizing test cases or test cycles). Filter by folderType (TEST_CASE / TEST_CYCLE) and parentId for subfolders. |
 | **list_priorities** / **list_statuses** | List test case priorities and statuses (id and name). Use the returned ids when creating or updating test cases. Optional projectKey. |
 | **list_environments** / **get_environment** / **create_environment** / **update_environment** | List and manage test environments per project (`GET/POST/PUT /environments`). Use returned names with **create_test_cycle** / **update_test_cycle** (`environment`) and **create_test_execution** (`environmentName`). |
@@ -153,12 +153,15 @@ list_projects({ limit: 20, startAt: 0 });
 ```ts
 create_test_plan({ name: "Release 2.0", projectKey: "ABC", description: "..." });
 list_test_plans({ projectKey: "ABC", limit: 50 });
+get_test_plan({ planKey: "ABC-P1" });
+update_test_plan({ planKey: "ABC-P1", name: "Release 2.0 RC", description: "..." });
 ```
 
 **Test cycles**
 ```ts
 create_test_cycle({ name: "Sprint 10", projectKey: "ABC", versionId: "10001", environment: "Production" });
 list_test_cycles({ projectKey: "ABC", limit: 25 });
+update_test_cycle({ cycleKey: "ABC-R1", name: "Sprint 10 (final)", status: "365024", customFields: { "Team": "QA" } });
 list_test_executions_in_cycle({ cycleId: "ABC-R1" });
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
@@ -291,7 +294,8 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Test steps as separate resource** — `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` (v0.7). Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER.
 - [x] **Remove test case from cycle** — `remove_test_case_from_cycle` calls `DELETE /testexecutions/{id}` (resolve via `list_test_executions_in_cycle` or pass `cycleKey` + `testCaseKey`). Official docs may not advertise this; some tenants return 404/405.
 - [x] **Test case ↔ Jira issue links (coverage)** — `link_tests_to_issues` uses **`POST /testcases/{key}/links/issues`** with numeric Jira issue id (v0.12.0). `get_test_case_links` lists links (**`GET /testcases/{key}/links`**). Older `POST .../links` + `issueKeys` is not used (405 on current API).
-- [ ] **Update test plan / test cycle** — PUT for plans and cycles (rename, dates, status).
+- [x] **Update test cycle** — **`update_test_cycle`**: **`PUT /testcycles/{key}`** (OpenAPI `updateTestCycle`); MCP merges from GET before PUT (including status, `versionId` → `jiraProjectVersion`, owner, custom fields).
+- [x] **Update test plan** — **`update_test_plan`**: GET-merge-PUT; **not** listed in the public OpenAPI for `PUT /testplans/{key}` — see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 - [ ] **Bulk operations** — Bulk execution updates or bulk add-to-cycle (beyond `create_multiple_test_cases`).
 
 ---

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -8,8 +8,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 | Area | Implemented |
 |------|-------------|
-| **Test plans** | Create, list (by projectKey) |
-| **Test cycles** | Create, list (by projectKey, optional versionId) |
+| **Test plans** | Create, list (by projectKey), get one, update (**`update_test_plan`**: GET-merge-PUT — **not** in public OpenAPI; see §14) |
+| **Test cycles** | Create, list (by projectKey, optional versionId), get one, **`update_test_cycle`** (PUT `testcycles/{key}`, OpenAPI `updateTestCycle`) |
 | **Test executions** | Create (add test case to cycle), get one, update status/comment/defects, list in cycle, summary by cycle |
 | **Test cases** | Get one, search, create, update, create multiple |
 | **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
@@ -96,12 +96,17 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 - **MCP status:** Implemented (`remove_test_case_from_cycle`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve a single matching execution. If more than one execution exists for the same case in the cycle, you must pass **`executionId`**.
 - **Caveat:** The public API reference does not always list this operation; some tenants return **404/405**. The Zephyr UI may use other backends for bulk removal; this tool targets the Scale Cloud v2 REST surface only.
 
-### 13. **Update test plan / Update test cycle**
+### 13. **Update test cycle**
 
-- **API:** `PUT /testplans/{key}`, `PUT /testcycles/{key}` (if supported).
-- **Gap:** Only create and list for plans and cycles. No update (e.g. rename, change dates, status) even if the API allows it.
+- **API (OpenAPI):** **`PUT /testcycles/{testCycleIdOrKey}`** — `operationId: updateTestCycle`. Request body is **`TestCycle`**; docs warn that omitted fields may be cleared and custom fields may need to be sent in full.
+- **MCP status:** Implemented (**`update_test_cycle`**, v0.6+; extended v0.13.0). Client **`GET`s** the cycle, **merges** partial fields (including **`status`** id, **`versionId`** → **`jiraProjectVersion`**, **`ownerAccountId`**, **`customFields`**), then **`PUT`s** so updates do not wipe the rest of the payload.
 
-### 14. **Bulk or batch operations**
+### 14. **Update test plan**
+
+- **API (OpenAPI, [api.cloud.stripped.yml](https://support.smartbear.com/zephyr-scale-cloud/api-docs/)):** **`GET /testplans/{testPlanIdOrKey}`** (`getTestPlan`) and **`POST /testplans`** (`createTestPlan`) are documented. The published spec does **not** list **`PUT /testplans/{key}`** for that path.
+- **MCP status (v0.13.0+):** **`update_test_plan`** uses the same **GET → merge → PUT** pattern as test cases and test cycles, calling **`PUT /testplans/{planKey}`** with the merged **`TestPlan`**-shaped body. This matches how the product UI typically persists plan edits, but **it is not guaranteed** on every region or tenant: you may see **404** or **405** if the endpoint is disabled. If so, edit the plan in the Zephyr UI or contact SmartBear.
+
+### 15. **Bulk or batch operations**
 
 - **API:** Any bulk endpoints (e.g. bulk update executions, bulk add to cycle) if present in the docs.
 - **Gap:** Only `create_multiple_test_cases` exists. No bulk execution updates or bulk cycle operations exposed.
@@ -124,9 +129,10 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 10 | Archive/delete test case | PUT archived; DELETE testcases/{key} | Implemented (`archive_test_case`, `unarchive_test_case`, `delete_test_case`, v0.11.0); API support varies by tenant |
 | 11 | Test steps CRUD | testcases/{key}/teststeps | Implemented (v0.7) |
 | 12 | Remove test case from cycle | DELETE /testexecutions/{id} | Implemented (`remove_test_case_from_cycle`; API support varies by tenant) |
-| 13 | Update test plan / test cycle | PUT testplans, testcycles | Not implemented |
-| 14 | Bulk operations (executions, cycle) | Bulk endpoints (if any) | Not implemented |
-| 15 | Test case ↔ Jira issue links | GET `testcases/{key}/links`, POST `testcases/{key}/links/issues` | Implemented (`get_test_case_links`, `link_tests_to_issues`, **v0.12.0**) |
+| 13 | Update test cycle | PUT `testcycles/{key}` | Implemented (`update_test_cycle`; GET-merge-PUT vs OpenAPI `updateTestCycle`) |
+| 14 | Update test plan | PUT `testplans/{key}` (undocumented in public OpenAPI) | Implemented (**`update_test_plan`**, v0.13.0); GET-merge-PUT — may 404/405 on some tenants |
+| 15 | Bulk operations (executions, cycle) | Bulk endpoints (if any) | Not implemented |
+| 16 | Test case ↔ Jira issue links | GET/POST `.../links` and `.../links/issues` | Implemented (**v0.12.0**); test case, cycle, and plan issue links |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -67,6 +67,57 @@ export class ZephyrClient {
     return response.data;
   }
 
+  /**
+   * Update a test plan: GET-merge-PUT. The published OpenAPI does not list PUT /testplans/{key};
+   * some tenants still accept it (same pattern as test cases / cycles).
+   */
+  async updateTestPlan(planKey: string, data: {
+    name?: string;
+    description?: string;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+    folderId?: string | number | null;
+    ownerAccountId?: string;
+    customFields?: Record<string, unknown>;
+    labels?: string[];
+  }): Promise<ZephyrTestPlan> {
+    const existing = (await this.client.get(`/testplans/${planKey}`)).data as Record<string, unknown>;
+    const payload: Record<string, unknown> = { ...existing };
+    if (data.name !== undefined) payload.name = data.name;
+    if (data.description !== undefined) {
+      payload.objective = data.description;
+      payload.description = data.description;
+    }
+    if (data.startDate !== undefined) payload.plannedStartDate = data.startDate;
+    if (data.endDate !== undefined) payload.plannedEndDate = data.endDate;
+    if (data.status !== undefined) payload.status = { id: Number(data.status) };
+    if (data.folderId !== undefined) {
+      if (data.folderId === null) {
+        payload.folder = null;
+      } else {
+        payload.folder = { id: Number(data.folderId) };
+      }
+    }
+    if (data.ownerAccountId !== undefined) {
+      const prev = existing.owner;
+      payload.owner = {
+        ...(prev && typeof prev === 'object' ? (prev as Record<string, unknown>) : {}),
+        accountId: data.ownerAccountId,
+      };
+    }
+    if (data.customFields !== undefined) {
+      const prev = existing.customFields;
+      payload.customFields = {
+        ...(typeof prev === 'object' && prev !== null ? (prev as Record<string, unknown>) : {}),
+        ...data.customFields,
+      };
+    }
+    if (data.labels !== undefined) payload.labels = data.labels;
+    const response = await this.client.put(`/testplans/${planKey}`, payload);
+    return response.data;
+  }
+
   async createTestCycle(data: {
     name: string;
     description?: string;
@@ -101,21 +152,43 @@ export class ZephyrClient {
     environment?: string;
     startDate?: string;
     endDate?: string;
+    status?: string;
+    versionId?: string;
+    ownerAccountId?: string;
+    customFields?: Record<string, unknown>;
   }): Promise<ZephyrTestCycle> {
-    const existing = (await this.client.get(`/testcycles/${cycleKey}`)).data;
-    const payload: Record<string, unknown> = {
-      ...existing,
-      id: existing.id,
-      key: existing.key,
-      name: data.name !== undefined ? data.name : existing.name,
-      description: data.description !== undefined ? data.description : existing.description,
-      status: existing.status,
-      project: existing.project ?? (existing.projectKey != null ? { id: existing.projectId ?? existing.projectKey } : undefined),
-      plannedStartDate: data.startDate !== undefined ? data.startDate : existing.plannedStartDate,
-      plannedEndDate: data.endDate !== undefined ? data.endDate : existing.plannedEndDate,
-    };
+    const existing = (await this.client.get(`/testcycles/${cycleKey}`)).data as Record<string, unknown>;
+    const payload: Record<string, unknown> = { ...existing };
+    if (data.name !== undefined) payload.name = data.name;
+    if (data.description !== undefined) payload.description = data.description;
+    if (data.startDate !== undefined) payload.plannedStartDate = data.startDate;
+    if (data.endDate !== undefined) payload.plannedEndDate = data.endDate;
     if (data.environment !== undefined) payload.environment = data.environment;
     if (data.folderId !== undefined) payload.folderId = data.folderId;
+    if (data.status !== undefined) payload.status = { id: Number(data.status) };
+    if (data.versionId !== undefined) {
+      const vid = Number(data.versionId);
+      const jpv = existing.jiraProjectVersion;
+      payload.jiraProjectVersion = {
+        ...(jpv && typeof jpv === 'object' ? (jpv as Record<string, unknown>) : {}),
+        id: vid,
+      };
+      if (existing.versionId !== undefined) payload.versionId = data.versionId;
+    }
+    if (data.ownerAccountId !== undefined) {
+      const prev = existing.owner;
+      payload.owner = {
+        ...(prev && typeof prev === 'object' ? (prev as Record<string, unknown>) : {}),
+        accountId: data.ownerAccountId,
+      };
+    }
+    if (data.customFields !== undefined) {
+      const prev = existing.customFields;
+      payload.customFields = {
+        ...(typeof prev === 'object' && prev !== null ? (prev as Record<string, unknown>) : {}),
+        ...data.customFields,
+      };
+    }
     const response = await this.client.put(`/testcycles/${cycleKey}`, payload);
     return response.data;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { readJiraIssue } from './tools/jira-issues.js';
-import { createTestPlan, listTestPlans, getTestPlan } from './tools/test-plans.js';
+import { createTestPlan, listTestPlans, getTestPlan, updateTestPlan } from './tools/test-plans.js';
 import { createTestCycle, listTestCycles, getTestCycle, addTestCasesToCycle, updateTestCycle } from './tools/test-cycles.js';
 import {
   createTestExecution,
@@ -43,6 +43,7 @@ import {
   createTestPlanSchema,
   listTestPlansSchema,
   getTestPlanSchema,
+  updateTestPlanSchema,
   createTestCycleSchema,
   listTestCyclesSchema,
   getTestCycleSchema,
@@ -83,6 +84,7 @@ import {
   CreateTestPlanInput,
   ListTestPlansInput,
   GetTestPlanInput,
+  UpdateTestPlanInput,
   CreateTestCycleInput,
   ListTestCyclesInput,
   GetTestCycleInput,
@@ -123,7 +125,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.12.0',
+    version: '0.13.0',
   },
   {
     capabilities: {
@@ -199,6 +201,27 @@ const TOOLS = [
     },
   },
   {
+    name: 'update_test_plan',
+    description:
+      'Update a test plan (GET-merge-PUT). Not listed in the public OpenAPI; may return 404/405 on some tenants. Supports name, description/objective, planned dates, status id, folderId, owner, customFields, labels.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        planKey: { type: 'string', description: 'Test plan key or ID' },
+        name: { type: 'string', description: 'New name (optional)' },
+        description: { type: 'string', description: 'New description / objective (optional)' },
+        startDate: { type: 'string', description: 'Planned start date ISO (optional)' },
+        endDate: { type: 'string', description: 'Planned end date ISO (optional)' },
+        status: { type: 'string', description: 'Zephyr status id (numeric string, optional)' },
+        folderId: { type: 'string', description: 'Folder id (optional); null to clear if supported' },
+        ownerAccountId: { type: 'string', description: 'Jira account id for owner (optional)' },
+        customFields: { type: 'object', description: 'Merged with existing custom fields (optional)' },
+        labels: { type: 'array', items: { type: 'string' }, description: 'Test plan labels (optional)' },
+      },
+      required: ['planKey'],
+    },
+  },
+  {
     name: 'create_test_cycle',
     description: 'Create a new test execution cycle',
     inputSchema: {
@@ -218,7 +241,8 @@ const TOOLS = [
   },
   {
     name: 'update_test_cycle',
-    description: 'Update a test cycle (e.g. name, description, folderId, dates)',
+    description:
+      'Update a test cycle (PUT /testcycles/{key}; GET-merge-PUT). Name, description, folderId, environment, dates, status id, Jira version id, owner, customFields.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -229,6 +253,10 @@ const TOOLS = [
         environment: { type: 'string', description: 'Environment (optional)' },
         startDate: { type: 'string', description: 'Planned start date ISO (optional)' },
         endDate: { type: 'string', description: 'Planned end date ISO (optional)' },
+        status: { type: 'string', description: 'Zephyr cycle status id (numeric string, optional)' },
+        versionId: { type: 'string', description: 'Jira release version id (optional; maps to jiraProjectVersion)' },
+        ownerAccountId: { type: 'string', description: 'Jira account id for owner (optional)' },
+        customFields: { type: 'object', description: 'Merged with existing custom fields (optional)' },
       },
       required: ['cycleKey'],
     },
@@ -839,6 +867,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await getTestPlan(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_test_plan': {
+        const validatedArgs = validateInput<UpdateTestPlanInput>(updateTestPlanSchema, args, 'update_test_plan');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await updateTestPlan(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-cycles.ts
+++ b/src/tools/test-cycles.ts
@@ -70,6 +70,10 @@ export const updateTestCycle = async (input: UpdateTestCycleInput) => {
       environment: validatedInput.environment,
       startDate: validatedInput.startDate,
       endDate: validatedInput.endDate,
+      status: validatedInput.status,
+      versionId: validatedInput.versionId,
+      ownerAccountId: validatedInput.ownerAccountId,
+      customFields: validatedInput.customFields,
     });
     return {
       success: true,

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -2,9 +2,11 @@ import { ZephyrClient } from '../clients/zephyr-client.js';
 import {
   createTestPlanSchema,
   listTestPlansSchema,
+  updateTestPlanSchema,
   CreateTestPlanInput,
   ListTestPlansInput,
   GetTestPlanInput,
+  UpdateTestPlanInput,
 } from '../utils/validation.js';
 
 let zephyrClient: ZephyrClient | null = null;
@@ -86,6 +88,42 @@ export const listTestPlans = async (input: ListTestPlansInput) => {
 export const getTestPlan = async (input: GetTestPlanInput) => {
   try {
     const testPlan = await getZephyrClient().getTestPlan(input.planKey);
+    return {
+      success: true,
+      data: {
+        id: testPlan.id,
+        key: testPlan.key,
+        name: testPlan.name,
+        description: testPlan.description,
+        projectId: testPlan.projectId,
+        status: testPlan.status,
+        createdOn: testPlan.createdOn,
+        updatedOn: testPlan.updatedOn,
+        createdBy: testPlan.createdBy?.displayName,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const updateTestPlan = async (input: UpdateTestPlanInput) => {
+  const validatedInput = updateTestPlanSchema.parse(input);
+  try {
+    const testPlan = await getZephyrClient().updateTestPlan(validatedInput.planKey, {
+      name: validatedInput.name,
+      description: validatedInput.description,
+      startDate: validatedInput.startDate,
+      endDate: validatedInput.endDate,
+      status: validatedInput.status,
+      folderId: validatedInput.folderId,
+      ownerAccountId: validatedInput.ownerAccountId,
+      customFields: validatedInput.customFields,
+      labels: validatedInput.labels,
+    });
     return {
       success: true,
       data: {

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -11,6 +11,9 @@ export interface ZephyrTestPlan {
     accountId: string;
     displayName: string;
   };
+  /** Present on some API responses (OpenAPI uses `objective`). */
+  objective?: string;
+  customFields?: Record<string, unknown>;
 }
 
 export interface ZephyrTestCycle {
@@ -28,6 +31,9 @@ export interface ZephyrTestCycle {
   actualEndDate?: string;
   createdOn: string;
   updatedOn: string;
+  customFields?: Record<string, unknown>;
+  jiraProjectVersion?: { id?: number; self?: string };
+  owner?: { accountId?: string; self?: string };
   /** Present on many list/detail responses; Zephyr Scale may omit on GET /testcycles/{key}. */
   executionSummary?: {
     total: number;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -39,6 +39,30 @@ export const getTestPlanSchema = z.object({
   planKey: z.string().min(1, 'Test plan key or ID is required'),
 });
 
+export const updateTestPlanSchema = z
+  .object({
+    planKey: z.string().min(1, 'Test plan key or ID is required'),
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    status: z.string().optional(),
+    folderId: z.union([z.string(), z.number(), z.null()]).optional(),
+    ownerAccountId: z.string().optional(),
+    customFields: z.record(z.string(), z.any()).optional(),
+    labels: z.array(z.string()).optional(),
+  })
+  .superRefine((val, ctx) => {
+    const { planKey: _p, ...rest } = val;
+    const hasUpdate = Object.values(rest).some(v => v !== undefined);
+    if (!hasUpdate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide at least one field to update (name, description, dates, status, folderId, ownerAccountId, customFields, labels).',
+      });
+    }
+  });
+
 export const listTestCyclesSchema = z.object({
   projectKey: z.string().min(1, 'Project key is required'),
   versionId: z.string().optional(),
@@ -57,6 +81,10 @@ export const updateTestCycleSchema = z.object({
   environment: z.string().optional(),
   startDate: z.string().optional(),
   endDate: z.string().optional(),
+  status: z.string().optional(),
+  versionId: z.string().optional(),
+  ownerAccountId: z.string().optional(),
+  customFields: z.record(z.string(), z.any()).optional(),
 });
 
 export const executeTestSchema = z.object({
@@ -319,6 +347,7 @@ export type ReadJiraIssueInput = z.infer<typeof readJiraIssueSchema>;
 export type ListProjectsInput = z.infer<typeof listProjectsSchema>;
 export type ListTestPlansInput = z.infer<typeof listTestPlansSchema>;
 export type GetTestPlanInput = z.infer<typeof getTestPlanSchema>;
+export type UpdateTestPlanInput = z.infer<typeof updateTestPlanSchema>;
 export type ListTestCyclesInput = z.infer<typeof listTestCyclesSchema>;
 export type GetTestCycleInput = z.infer<typeof getTestCycleSchema>;
 export type UpdateTestCycleInput = z.infer<typeof updateTestCycleSchema>;

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -111,6 +111,60 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('updateTestCycle', () => {
+    it('sends GET then PUT /v2/testcycles/{key} with merged body', async () => {
+      const getBody = {
+        ...loadFixture('testcycle-get.json'),
+        customFields: { a: 1 },
+        jiraProjectVersion: { id: 1, self: 'https://example.atlassian.net/rest/api/3/version/1' },
+      };
+      nock(ZEPHYR_ORIGIN).get(`${V2}/testcycles/PROJ-R1`).reply(200, getBody);
+      const put = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testcycles/PROJ-R1`, (body: Record<string, unknown>) => {
+          const cf = body.customFields as Record<string, number>;
+          const st = body.status as { id: number };
+          const jpv = body.jiraProjectVersion as { id: number };
+          return (
+            body.name === 'Renamed' &&
+            cf.a === 1 &&
+            cf.b === 2 &&
+            st.id === 99 &&
+            jpv.id === 5000
+          );
+        })
+        .reply(200, { ...getBody, name: 'Renamed' });
+
+      await client.updateTestCycle('PROJ-R1', {
+        name: 'Renamed',
+        status: '99',
+        versionId: '5000',
+        customFields: { b: 2 },
+      });
+
+      expect(put.isDone()).toBe(true);
+    });
+  });
+
+  describe('updateTestPlan', () => {
+    it('sends GET then PUT /v2/testplans/{key} with merged objective and description', async () => {
+      const body = loadFixture('testplan-get.json');
+      nock(ZEPHYR_ORIGIN).get(`${V2}/testplans/TP-1`).reply(200, body);
+      const put = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testplans/TP-1`, (reqBody: Record<string, unknown>) => {
+          return (
+            reqBody.name === 'Updated plan' &&
+            reqBody.objective === 'New objective' &&
+            reqBody.description === 'New objective'
+          );
+        })
+        .reply(200, { ...body, name: 'Updated plan', objective: 'New objective', description: 'New objective' });
+
+      await client.updateTestPlan('TP-1', { name: 'Updated plan', description: 'New objective' });
+
+      expect(put.isDone()).toBe(true);
+    });
+  });
+
   describe('getProjects', () => {
     it('sends GET /v2/projects with maxResults and startAt, returns list', async () => {
       const body = loadFixture('projects-list.json');


### PR DESCRIPTION
## Summary

This release extends **test cycle** updates to match the `TestCycle` model (status, Jira version, owner, custom fields) with a full GET-merge-PUT body, and adds **`update_test_plan`** using the same pattern. **Test plan PUT** is **not** listed in the public Zephyr Scale Cloud OpenAPI; the client calls `PUT /testplans/{key}` and may receive **404/405** on some tenants (documented in README and `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md`).

## Changes

- **`update_test_cycle`**: optional `status`, `versionId` (maps to `jiraProjectVersion.id`), `ownerAccountId`, `customFields` (merged with existing). Payload is built from `GET /testcycles/{key}` plus overrides so omitted API fields are preserved where the API returns them.
- **`update_test_plan`**: new MCP tool; requires at least one updatable field besides `planKey`. Supports `name`, `description` (maps to `objective` and `description` on PUT), `startDate` / `endDate` (`plannedStartDate` / `plannedEndDate`), `status`, `folderId`, `ownerAccountId`, `customFields`, `labels`.
- Version **0.13.0** in `package.json` and MCP `version` in `src/index.ts`.

## Tests

- `tests/zephyr-client.test.ts`: `updateTestCycle` (GET + PUT merge assertion), `updateTestPlan` (GET + PUT merge assertion).
- `npm test`, `npm run typecheck`, and `npm run build` pass locally.

## Docs

- `README.md`, `CLAUDE.md`, `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` updated.

## Upgrade notes

- Consumers can start using the new optional parameters on **`update_test_cycle`** immediately.
- For **`update_test_plan`**, validate against your Zephyr instance; if PUT is not supported, rely on the UI or contact SmartBear.
