### PR TITLE
v0.14.0: nextgen cursor lists + bulk_execute_tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ The following environment variables are required:
 - `get_test_cycle`: Get one test cycle by key or id
 - `update_test_cycle`: Update a test cycle (`PUT /testcycles/{key}`; GET-merge-PUT, including status, version, owner, custom fields)
 - `execute_test`: Update test execution results
+- `bulk_execute_tests`: Update many executions sequentially (one PUT each; no single bulk API in public spec)
+- `list_test_executions_nextgen`: Cursor-paged list of executions (`GET /testexecutions/nextgen`)
 - `get_test_execution_status`: Get test execution progress and statistics
 - `remove_test_case_from_cycle`: Remove a test case from a cycle (delete test execution by id or cycle + case key)
 - `link_tests_to_issues`: Link a test case to Jira issue(s) as coverage — `POST /testcases/{key}/links/issues` with `{ issueId }` (Jira Cloud numeric id); resolves keys via Jira REST `GET /issue/{key}` (v0.12.0)
@@ -37,6 +39,7 @@ The following environment variables are required:
 - `create_test_case`: Create a new test case in Zephyr
 - `create_multiple_test_cases`: Create multiple test cases in Zephyr at once
 - `search_test_cases`: Search for test cases in a project
+- `list_test_cases_nextgen`: Cursor-paged test cases (`GET /testcases/nextgen`)
 - `get_test_case`: Get detailed information about a specific test case
 - `archive_test_case` / `unarchive_test_case` / `delete_test_case`: Archive, unarchive, or delete a test case (API support varies by tenant)
 - `list_environments` / `get_environment` / `create_environment` / `update_environment`: List and manage Zephyr test environments per project

--- a/README.md
+++ b/README.md
@@ -118,14 +118,16 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **list_priorities** / **list_statuses** | List test case priorities and statuses (id and name). Use the returned ids when creating or updating test cases. Optional projectKey. |
 | **list_environments** / **get_environment** / **create_environment** / **update_environment** | List and manage test environments per project (`GET/POST/PUT /environments`). Use returned names with **create_test_cycle** / **update_test_cycle** (`environment`) and **create_test_execution** (`environmentName`). |
 | **list_projects** | List Zephyr-visible projects (id, key, name). Optional `limit`, `startAt` for pagination. Use for projectKey discovery. |
-| **list_test_executions_in_cycle** | List test cases and executions in a cycle. |
+| **list_test_executions_in_cycle** | List test cases and executions in a cycle (`GET /testexecutions` with `testCycle`). |
+| **list_test_executions_nextgen** | Cursor-paged executions for large volumes ([`GET /testexecutions/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/listTestExecutionsNextgen)); use `nextStartAtId` or `next` for the next page. |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
 | **remove_test_case_from_cycle** | Remove a test case from a cycle by deleting its test execution (`DELETE /testexecutions/{id}`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve it. If the public API returns 404/405 on your instance, use the Zephyr UI or contact SmartBear. |
-| **create_test_case** / **search_test_cases** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
+| **create_test_case** / **search_test_cases** / **list_test_cases_nextgen** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, cursor list ([`GET /testcases/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/listTestCasesCursorPaginated)), get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
 | **archive_test_case** / **unarchive_test_case** / **delete_test_case** | Archive via PUT (`archived` flag), unarchive, or DELETE. **API support varies** — some instances reject `archived` or DELETE; see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md). |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
-| **execute_test** | Update test execution status (PASS/FAIL/WIP/BLOCKED). |
+| **execute_test** | Update one test execution status (PASS/FAIL/WIP/BLOCKED). |
+| **bulk_execute_tests** | Update many executions **sequentially** (one `PUT /testexecutions/{id}` per item). The public API has **no** single bulk-update call; optional `continueOnError` (default true), same idea as `create_multiple_test_cases`. |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
 | **link_tests_to_issues** | Link a test case to Jira issue(s) as **coverage** ([`POST .../testcases/{key}/links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/createTestCaseIssueLink)). Resolves each issue **key** to a numeric id via Jira REST, then calls Zephyr (v0.12.0; replaces the old `POST .../links` + `issueKeys` shape). |
 | **get_test_case_links** | List Jira issue links and web links for a test case ([`GET .../testcases/{key}/links`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/getTestCaseLinks)). |
@@ -163,6 +165,7 @@ create_test_cycle({ name: "Sprint 10", projectKey: "ABC", versionId: "10001", en
 list_test_cycles({ projectKey: "ABC", limit: 25 });
 update_test_cycle({ cycleKey: "ABC-R1", name: "Sprint 10 (final)", status: "365024", customFields: { "Team": "QA" } });
 list_test_executions_in_cycle({ cycleId: "ABC-R1" });
+list_test_executions_nextgen({ testCycle: "ABC-R1", limit: 100, startAtId: 0 });  // next page: pass startAtId from nextStartAtId
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
 create_test_execution({ projectKey: "ABC", testCycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
@@ -200,6 +203,7 @@ create_test_case({ projectKey: "ABC", name: "Login test", objective: "...", test
 create_test_case({ projectKey: "ABC", name: "Free text test", testScript: { type: "PLAIN_TEXT", text: "Manual instructions here." } });
 create_test_case({ projectKey: "ABC", name: "BDD scenario", testScript: { type: "CUCUMBER", text: "Given ... When ... Then ..." });  // CUCUMBER if supported by instance
 search_test_cases({ projectKey: "ABC", query: "login", limit: 20 });
+list_test_cases_nextgen({ projectKey: "ABC", limit: 200, startAtId: 0 });
 get_test_case({ testCaseId: "ABC-T123" });
 update_test_case({ testCaseId: "ABC-T123", customFields: { "Created On": "2026-03-11" } });
 create_multiple_test_cases({ testCases: [...], continueOnError: true });
@@ -219,6 +223,7 @@ delete_test_step({ testCaseKey: "ABC-T123", stepId: 2 });
 **Execution and reporting**
 ```ts
 execute_test({ executionId: "12345", status: "PASS", comment: "All passed" });
+bulk_execute_tests({ executions: [{ executionId: "12345", status: "PASS" }, { executionId: "12346", status: "FAIL" }], continueOnError: true });
 get_test_execution_status({ cycleId: "67890" });
 link_tests_to_issues({ testCaseId: "ABC-T123", issueKeys: ["ABC-456"] });
 link_test_cycle_to_issues({ cycleKey: "ABC-R1", issueKeys: ["ABC-456"] });
@@ -296,7 +301,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Test case ↔ Jira issue links (coverage)** — `link_tests_to_issues` uses **`POST /testcases/{key}/links/issues`** with numeric Jira issue id (v0.12.0). `get_test_case_links` lists links (**`GET /testcases/{key}/links`**). Older `POST .../links` + `issueKeys` is not used (405 on current API).
 - [x] **Update test cycle** — **`update_test_cycle`**: **`PUT /testcycles/{key}`** (OpenAPI `updateTestCycle`); MCP merges from GET before PUT (including status, `versionId` → `jiraProjectVersion`, owner, custom fields).
 - [x] **Update test plan** — **`update_test_plan`**: GET-merge-PUT; **not** listed in the public OpenAPI for `PUT /testplans/{key}` — see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
-- [ ] **Bulk operations** — Bulk execution updates or bulk add-to-cycle (beyond `create_multiple_test_cases`).
+- [x] **Bulk / high-volume operations (v0.14.0)** — **`list_test_cases_nextgen`** / **`list_test_executions_nextgen`** (cursor pagination per OpenAPI). **`bulk_execute_tests`** (sequential PUTs; no single bulk endpoint in the public spec). See [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 
 ---
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -10,8 +10,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 |------|-------------|
 | **Test plans** | Create, list (by projectKey), get one, update (**`update_test_plan`**: GET-merge-PUT — **not** in public OpenAPI; see §14) |
 | **Test cycles** | Create, list (by projectKey, optional versionId), get one, **`update_test_cycle`** (PUT `testcycles/{key}`, OpenAPI `updateTestCycle`) |
-| **Test executions** | Create (add test case to cycle), get one, update status/comment/defects, list in cycle, summary by cycle |
-| **Test cases** | Get one, search, create, update, create multiple |
+| **Test executions** | Create (add test case to cycle), get one, update status/comment/defects, list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
+| **Test cases** | Get one, search, cursor list (**`list_test_cases_nextgen`**, v0.14.0), create, update, create multiple |
 | **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
 | **Priorities / statuses** | List priorities and statuses (GET /priorities, GET /statuses; optional projectKey) for test case create/update |
 | **Links** | Coverage links to Jira issues: POST `testcases/{key}/links/issues`, `testcycles/{key}/links/issues`, `testplans/{key}/links/issues` (numeric `issueId`; MCP resolves keys via Jira REST). List (test case only): GET `testcases/{key}/links` (`get_test_case_links`). **v0.12.0+** — see note below. |
@@ -108,8 +108,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 ### 15. **Bulk or batch operations**
 
-- **API:** Any bulk endpoints (e.g. bulk update executions, bulk add to cycle) if present in the docs.
-- **Gap:** Only `create_multiple_test_cases` exists. No bulk execution updates or bulk cycle operations exposed.
+- **API (OpenAPI):** There is **no** documented endpoint that accepts **multiple test execution updates in one request**. **`GET /testcases/nextgen`** (`listTestCasesCursorPaginated`) and **`GET /testexecutions/nextgen`** (`listTestExecutionsNextgen`) are **cursor-paged list** APIs for **large read volumes** (use `nextStartAtId` / `next` for the next page). **`POST /testcycles/{key}/testcases`** with an `items` array adds several cases to a cycle in one call — already exposed as **`add_test_cases_to_cycle`** (may 404 on some regions).
+- **MCP status (v0.14.0+):** **`list_test_cases_nextgen`** and **`list_test_executions_nextgen`** call the documented nextgen GET routes. **`bulk_execute_tests`** applies the same payload as **`execute_test`** via **sequential `PUT /testexecutions/{id}`** calls (optional **`continueOnError`**, same pattern as **`create_multiple_test_cases`**). For very large batches, prefer external orchestration or rate limits to avoid throttling.
 
 ---
 
@@ -131,7 +131,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 12 | Remove test case from cycle | DELETE /testexecutions/{id} | Implemented (`remove_test_case_from_cycle`; API support varies by tenant) |
 | 13 | Update test cycle | PUT `testcycles/{key}` | Implemented (`update_test_cycle`; GET-merge-PUT vs OpenAPI `updateTestCycle`) |
 | 14 | Update test plan | PUT `testplans/{key}` (undocumented in public OpenAPI) | Implemented (**`update_test_plan`**, v0.13.0); GET-merge-PUT — may 404/405 on some tenants |
-| 15 | Bulk operations (executions, cycle) | Bulk endpoints (if any) | Not implemented |
+| 15 | Bulk / high-volume reads & batch execution updates | `.../nextgen` GET; no multi-execution PUT in spec | **`list_test_cases_nextgen`**, **`list_test_executions_nextgen`**; **`bulk_execute_tests`** (sequential PUTs, v0.14.0) |
 | 16 | Test case ↔ Jira issue links | GET/POST `.../links` and `.../links/issues` | Implemented (**v0.12.0**); test case, cycle, and plan issue links |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -13,6 +13,7 @@ import {
   ZephyrTestStep,
   ZephyrProject,
   ZephyrEnvironment,
+  ZephyrCursorPage,
 } from '../types/zephyr-types.js';
 
 export class ZephyrClient {
@@ -447,6 +448,96 @@ export class ZephyrClient {
     return response.data;
   }
 
+  /**
+   * GET /testexecutions/nextgen — cursor-paged test executions for large volumes (OpenAPI `listTestExecutionsNextgen`).
+   * Use `nextStartAtId` (or the `next` URL) for the following page.
+   */
+  async listTestExecutionsNextgen(options: {
+    projectKey?: string;
+    testCycle?: string;
+    testCase?: string;
+    actualEndDateAfter?: string;
+    actualEndDateBefore?: string;
+    includeStepLinks?: boolean;
+    jiraProjectVersionId?: number;
+    onlyLastExecutions?: boolean;
+    limit?: number;
+    startAtId?: number;
+  }): Promise<ZephyrCursorPage & { values: ZephyrTestExecution[] }> {
+    const params: Record<string, string | number | boolean> = {
+      limit: options.limit ?? 50,
+      startAtId: options.startAtId ?? 0,
+    };
+    if (options.projectKey !== undefined) params.projectKey = options.projectKey;
+    if (options.testCycle !== undefined) params.testCycle = options.testCycle;
+    if (options.testCase !== undefined) params.testCase = options.testCase;
+    if (options.actualEndDateAfter !== undefined) params.actualEndDateAfter = options.actualEndDateAfter;
+    if (options.actualEndDateBefore !== undefined) params.actualEndDateBefore = options.actualEndDateBefore;
+    if (options.includeStepLinks !== undefined) params.includeStepLinks = options.includeStepLinks;
+    if (options.jiraProjectVersionId !== undefined) params.jiraProjectVersionId = options.jiraProjectVersionId;
+    if (options.onlyLastExecutions !== undefined) params.onlyLastExecutions = options.onlyLastExecutions;
+
+    const response = await this.client.get('/testexecutions/nextgen', { params });
+    const d = response.data as Record<string, unknown>;
+    const values = (d.values as ZephyrTestExecution[]) ?? [];
+    return {
+      values: Array.isArray(values) ? values : [],
+      limit: Number(d.limit ?? 0),
+      nextStartAtId: d.nextStartAtId != null ? Number(d.nextStartAtId) : null,
+      next: d.next != null ? String(d.next) : null,
+    };
+  }
+
+  /**
+   * Sequentially PUT each test execution (same contract as `execute_test`). There is no documented single-request
+   * bulk update for executions in the public Scale Cloud API; this helper mirrors `create_multiple_test_cases`.
+   */
+  async bulkExecuteTests(
+    items: Array<{
+      executionId: string;
+      status: 'PASS' | 'FAIL' | 'WIP' | 'BLOCKED';
+      comment?: string;
+      defects?: string[];
+    }>,
+    continueOnError = true
+  ): Promise<{
+    results: Array<{
+      index: number;
+      success: boolean;
+      data?: ZephyrTestExecution;
+      error?: string;
+    }>;
+    summary: { total: number; successful: number; failed: number };
+  }> {
+    const results: Array<{
+      index: number;
+      success: boolean;
+      data?: ZephyrTestExecution;
+      error?: string;
+    }> = [];
+    let successful = 0;
+    let failed = 0;
+
+    for (let i = 0; i < items.length; i++) {
+      try {
+        const data = await this.updateTestExecution(items[i]);
+        results.push({ index: i, success: true, data });
+        successful++;
+      } catch (error: unknown) {
+        const err = error as { response?: { data?: { message?: string } }; message?: string };
+        const errorMessage = err.response?.data?.message || err.message || String(error);
+        results.push({ index: i, success: false, error: errorMessage });
+        failed++;
+        if (!continueOnError) break;
+      }
+    }
+
+    return {
+      results,
+      summary: { total: items.length, successful, failed },
+    };
+  }
+
   async getTestExecutionsInCycle(cycleId: string): Promise<{
     executions: ZephyrTestExecution[];
     total: number;
@@ -663,6 +754,33 @@ export class ZephyrClient {
     return {
       testCases: response.data.values || response.data,
       total: response.data.total || response.data.length,
+    };
+  }
+
+  /**
+   * GET /testcases/nextgen — cursor-paged test cases for large volumes (OpenAPI `listTestCasesCursorPaginated`).
+   */
+  async listTestCasesNextgen(options: {
+    projectKey?: string;
+    folderId?: number;
+    limit?: number;
+    startAtId?: number;
+  }): Promise<ZephyrCursorPage & { values: ZephyrTestCase[] }> {
+    const params: Record<string, string | number> = {
+      limit: options.limit ?? 50,
+      startAtId: options.startAtId ?? 0,
+    };
+    if (options.projectKey !== undefined) params.projectKey = options.projectKey;
+    if (options.folderId !== undefined) params.folderId = options.folderId;
+
+    const response = await this.client.get('/testcases/nextgen', { params });
+    const d = response.data as Record<string, unknown>;
+    const values = (d.values as ZephyrTestCase[]) ?? [];
+    return {
+      values: Array.isArray(values) ? values : [],
+      limit: Number(d.limit ?? 0),
+      nextStartAtId: d.nextStartAtId != null ? Number(d.nextStartAtId) : null,
+      next: d.next != null ? String(d.next) : null,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,10 @@ import {
   createTestExecution,
   removeTestCaseFromCycle,
   executeTest,
+  bulkExecuteTests,
   getTestExecutionStatus,
   listTestExecutionsInCycle,
+  listTestExecutionsNextgen,
   linkTestsToIssues,
   linkTestCycleToIssues,
   linkTestPlanToIssues,
@@ -24,6 +26,7 @@ import {
 import {
   createTestCase,
   searchTestCases,
+  listTestCasesNextgen,
   getTestCase,
   getTestCaseLinks,
   updateTestCase,
@@ -51,6 +54,8 @@ import {
   executeTestSchema,
   getTestExecutionStatusSchema,
   listTestExecutionsInCycleSchema,
+  listTestExecutionsNextgenSchema,
+  bulkExecuteTestsSchema,
   addTestCasesToCycleSchema,
   createTestExecutionSchema,
   removeTestCaseFromCycleSchema,
@@ -68,6 +73,7 @@ import {
   generateTestReportSchema,
   createTestCaseSchema,
   searchTestCasesSchema,
+  listTestCasesNextgenSchema,
   getTestCaseSchema,
   getTestCaseLinksSchema,
   updateTestCaseSchema,
@@ -92,6 +98,8 @@ import {
   ExecuteTestInput,
   GetTestExecutionStatusInput,
   ListTestExecutionsInCycleInput,
+  ListTestExecutionsNextgenInput,
+  BulkExecuteTestsInput,
   AddTestCasesToCycleInput,
   CreateTestExecutionInput,
   RemoveTestCaseFromCycleInput,
@@ -109,6 +117,7 @@ import {
   GenerateTestReportInput,
   CreateTestCaseInput,
   SearchTestCasesInput,
+  ListTestCasesNextgenInput,
   GetTestCaseInput,
   GetTestCaseLinksInput,
   UpdateTestCaseInput,
@@ -125,7 +134,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.13.0',
+    version: '0.14.0',
   },
   {
     capabilities: {
@@ -297,6 +306,27 @@ const TOOLS = [
     },
   },
   {
+    name: 'list_test_executions_nextgen',
+    description:
+      'List test executions with cursor pagination (GET /testexecutions/nextgen). For large volumes; use nextStartAtId or next URL for the next page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key filter (optional)' },
+        testCycle: { type: 'string', description: 'Test cycle key filter (optional)' },
+        testCase: { type: 'string', description: 'Test case key or id filter (optional)' },
+        actualEndDateAfter: { type: 'string', description: 'ISO date-time filter (optional)' },
+        actualEndDateBefore: { type: 'string', description: 'ISO date-time filter (optional)' },
+        includeStepLinks: { type: 'boolean', description: 'Include step issue links (optional)' },
+        jiraProjectVersionId: { type: 'number', description: 'Jira release version id (optional)' },
+        onlyLastExecutions: { type: 'boolean', description: 'Only last execution per cycle item (optional)' },
+        limit: { type: 'number', description: 'Page size 1–1000 (default 50)' },
+        startAtId: { type: 'number', description: 'Cursor / startAtId for pagination (default 0)' },
+      },
+      required: [],
+    },
+  },
+  {
     name: 'add_test_cases_to_cycle',
     description: 'Add existing test cases to a test cycle',
     inputSchema: {
@@ -358,6 +388,32 @@ const TOOLS = [
         defects: { type: 'array', items: { type: 'string' }, description: 'Linked defect keys (optional)' },
       },
       required: ['executionId', 'status'],
+    },
+  },
+  {
+    name: 'bulk_execute_tests',
+    description:
+      'Update many test executions sequentially (one PUT per item). The public API has no single bulk-update endpoint; mirrors create_multiple_test_cases. Optional continueOnError (default true).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executions: {
+          type: 'array',
+          description: 'Each item: executionId, status (PASS|FAIL|WIP|BLOCKED), optional comment and defects',
+          items: {
+            type: 'object',
+            properties: {
+              executionId: { type: 'string' },
+              status: { type: 'string', enum: ['PASS', 'FAIL', 'WIP', 'BLOCKED'] },
+              comment: { type: 'string' },
+              defects: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['executionId', 'status'],
+          },
+        },
+        continueOnError: { type: 'boolean', description: 'If false, stop on first failure (default true)' },
+      },
+      required: ['executions'],
     },
   },
   {
@@ -631,6 +687,21 @@ const TOOLS = [
         limit: { type: 'number', description: 'Maximum number of results (default: 50)' },
       },
       required: ['projectKey'],
+    },
+  },
+  {
+    name: 'list_test_cases_nextgen',
+    description:
+      'List test cases with cursor pagination (GET /testcases/nextgen). For large volumes; use nextStartAtId or next URL for the next page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectKey: { type: 'string', description: 'JIRA project key filter (optional; may be required if user has access to many projects)' },
+        folderId: { type: 'number', description: 'Folder id filter (optional)' },
+        limit: { type: 'number', description: 'Page size 1–1000 (default 50)' },
+        startAtId: { type: 'number', description: 'Cursor / startAtId for pagination (default 0)' },
+      },
+      required: [],
     },
   },
   {
@@ -944,6 +1015,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'bulk_execute_tests': {
+        const validatedArgs = validateInput<BulkExecuteTestsInput>(bulkExecuteTestsSchema, args, 'bulk_execute_tests');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await bulkExecuteTests(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
       case 'get_test_execution_status': {
         const validatedArgs = validateInput<GetTestExecutionStatusInput>(getTestExecutionStatusSchema, args, 'get_test_execution_status');
         return {
@@ -963,6 +1046,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await listTestExecutionsInCycle(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_test_executions_nextgen': {
+        const validatedArgs = validateInput<ListTestExecutionsNextgenInput>(
+          listTestExecutionsNextgenSchema,
+          args,
+          'list_test_executions_nextgen'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await listTestExecutionsNextgen(validatedArgs), null, 2),
             },
           ],
         };
@@ -1179,6 +1278,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await searchTestCases(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'list_test_cases_nextgen': {
+        const validatedArgs = validateInput<ListTestCasesNextgenInput>(
+          listTestCasesNextgenSchema,
+          args,
+          'list_test_cases_nextgen'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await listTestCasesNextgen(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-cases.ts
+++ b/src/tools/test-cases.ts
@@ -3,6 +3,7 @@ import { getZephyrBaseUrl } from '../utils/config.js';
 import {
   createTestCaseSchema,
   searchTestCasesSchema,
+  listTestCasesNextgenSchema,
   createMultipleTestCasesSchema,
   updateTestCaseSchema,
   archiveTestCaseSchema,
@@ -11,6 +12,7 @@ import {
   getTestCaseLinksSchema,
   CreateTestCaseInput,
   SearchTestCasesInput,
+  ListTestCasesNextgenInput,
   CreateMultipleTestCasesInput,
   UpdateTestCaseInput,
   ArchiveTestCaseInput,
@@ -109,6 +111,46 @@ export const searchTestCases = async (input: SearchTestCasesInput) => {
         })),
         total: result.total,
         projectKey: validatedInput.projectKey,
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const listTestCasesNextgen = async (input: ListTestCasesNextgenInput) => {
+  const validatedInput = listTestCasesNextgenSchema.parse(input);
+  try {
+    const page = await getZephyrClient().listTestCasesNextgen({
+      projectKey: validatedInput.projectKey,
+      folderId: validatedInput.folderId,
+      limit: validatedInput.limit,
+      startAtId: validatedInput.startAtId,
+    });
+    return {
+      success: true,
+      data: {
+        limit: page.limit,
+        nextStartAtId: page.nextStartAtId,
+        next: page.next,
+        testCases: page.values.map(testCase => ({
+          id: testCase.id,
+          key: testCase.key,
+          name: testCase.name,
+          objective: testCase.objective,
+          precondition: testCase.precondition,
+          estimatedTime: testCase.estimatedTime,
+          priority: testCase.priority?.id,
+          status: testCase.status?.id,
+          folder: testCase.folder?.id,
+          labels: testCase.labels || [],
+          component: testCase.component?.id,
+          owner: testCase.owner?.accountId,
+          createdOn: testCase.createdOn,
+        })),
       },
     };
   } catch (error: any) {

--- a/src/tools/test-execution.ts
+++ b/src/tools/test-execution.ts
@@ -4,6 +4,8 @@ import {
   executeTestSchema,
   getTestExecutionStatusSchema,
   listTestExecutionsInCycleSchema,
+  listTestExecutionsNextgenSchema,
+  bulkExecuteTestsSchema,
   linkTestsToIssuesSchema,
   linkTestCycleToIssuesSchema,
   linkTestPlanToIssuesSchema,
@@ -13,6 +15,8 @@ import {
   ExecuteTestInput,
   GetTestExecutionStatusInput,
   ListTestExecutionsInCycleInput,
+  ListTestExecutionsNextgenInput,
+  BulkExecuteTestsInput,
   LinkTestsToIssuesInput,
   LinkTestCycleToIssuesInput,
   LinkTestPlanToIssuesInput,
@@ -143,6 +147,89 @@ export const listTestExecutionsInCycle = async (input: ListTestExecutionsInCycle
           executedBy: ex.executedBy?.displayName,
           defects: ex.defects?.map((d: any) => ({ key: d.key, summary: d.summary })) ?? [],
         })),
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const listTestExecutionsNextgen = async (input: ListTestExecutionsNextgenInput) => {
+  const validatedInput = listTestExecutionsNextgenSchema.parse(input);
+  try {
+    const page = await getZephyrClient().listTestExecutionsNextgen({
+      projectKey: validatedInput.projectKey,
+      testCycle: validatedInput.testCycle,
+      testCase: validatedInput.testCase,
+      actualEndDateAfter: validatedInput.actualEndDateAfter,
+      actualEndDateBefore: validatedInput.actualEndDateBefore,
+      includeStepLinks: validatedInput.includeStepLinks,
+      jiraProjectVersionId: validatedInput.jiraProjectVersionId,
+      onlyLastExecutions: validatedInput.onlyLastExecutions,
+      limit: validatedInput.limit,
+      startAtId: validatedInput.startAtId,
+    });
+    return {
+      success: true,
+      data: {
+        limit: page.limit,
+        nextStartAtId: page.nextStartAtId,
+        next: page.next,
+        executions: page.values.map((ex: any) => ({
+          id: ex.id,
+          key: ex.key,
+          cycleId: ex.cycleId,
+          testCaseId: ex.testCaseId ?? ex.testCase?.key,
+          testCaseKey: ex.testCase?.key ?? ex.testCaseKey,
+          status: ex.status,
+          comment: ex.comment,
+          executedOn: ex.executedOn,
+          executedBy: ex.executedBy?.displayName,
+          defects: ex.defects?.map((d: any) => ({ key: d.key, summary: d.summary })) ?? [],
+        })),
+      },
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.response?.data?.message || error.message,
+    };
+  }
+};
+
+export const bulkExecuteTests = async (input: BulkExecuteTestsInput) => {
+  const validatedInput = bulkExecuteTestsSchema.parse(input);
+  try {
+    const result = await getZephyrClient().bulkExecuteTests(
+      validatedInput.executions,
+      validatedInput.continueOnError
+    );
+    return {
+      success: true,
+      data: {
+        results: result.results.map(r => ({
+          index: r.index,
+          success: r.success,
+          execution:
+            r.success && r.data
+              ? {
+                  id: r.data.id,
+                  key: r.data.key,
+                  cycleId: r.data.cycleId,
+                  testCaseId: r.data.testCaseId,
+                  status: r.data.status,
+                  comment: r.data.comment,
+                  executedOn: r.data.executedOn,
+                  executedBy: r.data.executedBy?.displayName,
+                  defects: r.data.defects?.map(d => ({ key: d.key, summary: d.summary })) ?? [],
+                }
+              : undefined,
+          error: r.error,
+        })),
+        summary: result.summary,
       },
     };
   } catch (error: any) {

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -45,6 +45,13 @@ export interface ZephyrTestCycle {
   };
 }
 
+/** Cursor-style page metadata from GET `/testcases/nextgen` and `/testexecutions/nextgen`. */
+export interface ZephyrCursorPage {
+  limit: number;
+  nextStartAtId: number | null;
+  next: string | null;
+}
+
 export interface ZephyrTestExecution {
   id: string;
   key: string;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -102,6 +102,41 @@ export const listTestExecutionsInCycleSchema = z.object({
   cycleId: z.string().min(1, 'Cycle ID or key is required'),
 });
 
+/** GET /testexecutions/nextgen — cursor pagination for large result sets. */
+export const listTestExecutionsNextgenSchema = z.object({
+  projectKey: z.string().optional(),
+  testCycle: z.string().optional(),
+  testCase: z.string().optional(),
+  actualEndDateAfter: z.string().optional(),
+  actualEndDateBefore: z.string().optional(),
+  includeStepLinks: z.boolean().optional(),
+  jiraProjectVersionId: z.number().int().positive().optional(),
+  onlyLastExecutions: z.boolean().optional(),
+  limit: z.number().min(1).max(1000).default(50),
+  startAtId: z.number().min(0).default(0),
+});
+
+/** GET /testcases/nextgen — cursor pagination for large result sets. */
+export const listTestCasesNextgenSchema = z.object({
+  projectKey: z.string().optional(),
+  folderId: z.number().int().positive().optional(),
+  limit: z.number().min(1).max(1000).default(50),
+  startAtId: z.number().min(0).default(0),
+});
+
+const singleExecutionUpdateSchema = z.object({
+  executionId: z.string().min(1, 'Execution ID is required'),
+  status: z.enum(['PASS', 'FAIL', 'WIP', 'BLOCKED']),
+  comment: z.string().optional(),
+  defects: z.array(z.string()).optional(),
+});
+
+/** Sequential PUTs; no single bulk endpoint in the public API. */
+export const bulkExecuteTestsSchema = z.object({
+  executions: z.array(singleExecutionUpdateSchema).min(1, 'At least one execution update is required'),
+  continueOnError: z.boolean().default(true),
+});
+
 export const addTestCasesToCycleSchema = z.object({
   cycleKey: z.string().min(1, 'Test cycle key is required'),
   testCaseKeys: z.array(z.string().min(1)).min(1, 'At least one test case key is required'),
@@ -354,6 +389,9 @@ export type UpdateTestCycleInput = z.infer<typeof updateTestCycleSchema>;
 export type ExecuteTestInput = z.infer<typeof executeTestSchema>;
 export type GetTestExecutionStatusInput = z.infer<typeof getTestExecutionStatusSchema>;
 export type ListTestExecutionsInCycleInput = z.infer<typeof listTestExecutionsInCycleSchema>;
+export type ListTestExecutionsNextgenInput = z.infer<typeof listTestExecutionsNextgenSchema>;
+export type ListTestCasesNextgenInput = z.infer<typeof listTestCasesNextgenSchema>;
+export type BulkExecuteTestsInput = z.infer<typeof bulkExecuteTestsSchema>;
 export type AddTestCasesToCycleInput = z.infer<typeof addTestCasesToCycleSchema>;
 export type LinkTestsToIssuesInput = z.infer<typeof linkTestsToIssuesSchema>;
 export type LinkTestCycleToIssuesInput = z.infer<typeof linkTestCycleToIssuesSchema>;

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -165,6 +165,98 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('listTestCasesNextgen', () => {
+    it('sends GET /v2/testcases/nextgen with cursor params', async () => {
+      const body = {
+        values: [{ id: 1, key: 'PROJ-T1', name: 'TC1' }],
+        limit: 50,
+        nextStartAtId: 99,
+        next: 'https://api.zephyrscale.smartbear.com/v2/testcases/nextgen?startAtId=99',
+      };
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testcases/nextgen`)
+        .query({ projectKey: 'PROJ', limit: 50, startAtId: 0 })
+        .reply(200, body);
+
+      const result = await client.listTestCasesNextgen({ projectKey: 'PROJ', limit: 50, startAtId: 0 });
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].key).toBe('PROJ-T1');
+      expect(result.nextStartAtId).toBe(99);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('listTestExecutionsNextgen', () => {
+    it('sends GET /v2/testexecutions/nextgen with filters', async () => {
+      const body = {
+        values: [
+          {
+            id: '1',
+            key: 'PROJ-E1',
+            status: 'PASS',
+            cycleId: 'c',
+            testCaseId: 't',
+            defects: [],
+          },
+        ],
+        limit: 25,
+        nextStartAtId: null,
+        next: null,
+      };
+      const scope = nock(ZEPHYR_ORIGIN)
+        .get(`${V2}/testexecutions/nextgen`)
+        .query({ testCycle: 'PROJ-R1', limit: 25, startAtId: 0 })
+        .reply(200, body);
+
+      const result = await client.listTestExecutionsNextgen({ testCycle: 'PROJ-R1', limit: 25 });
+
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].status).toBe('PASS');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('bulkExecuteTests', () => {
+    it('sends sequential PUTs for each execution', async () => {
+      const put1 = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testexecutions/e1`, (b: Record<string, unknown>) => b.status === 'PASS')
+        .reply(200, { id: 'e1', key: 'E1', cycleId: 'c', testCaseId: 't', status: 'PASS', defects: [] });
+      const put2 = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testexecutions/e2`, (b: Record<string, unknown>) => b.status === 'FAIL')
+        .reply(200, { id: 'e2', key: 'E2', cycleId: 'c', testCaseId: 't', status: 'FAIL', defects: [] });
+
+      const result = await client.bulkExecuteTests([
+        { executionId: 'e1', status: 'PASS' },
+        { executionId: 'e2', status: 'FAIL' },
+      ]);
+
+      expect(result.summary.successful).toBe(2);
+      expect(result.results.every(r => r.success)).toBe(true);
+      expect(put1.isDone()).toBe(true);
+      expect(put2.isDone()).toBe(true);
+    });
+
+    it('stops on first error when continueOnError is false', async () => {
+      nock(ZEPHYR_ORIGIN).put(`${V2}/testexecutions/bad-ex`, () => true).reply(400, { message: 'nope' });
+      const put2 = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testexecutions/good-ex`)
+        .reply(200, { id: 'good-ex', key: 'G', cycleId: 'c', testCaseId: 't', status: 'PASS', defects: [] });
+
+      const result = await client.bulkExecuteTests(
+        [
+          { executionId: 'bad-ex', status: 'PASS' },
+          { executionId: 'good-ex', status: 'PASS' },
+        ],
+        false
+      );
+
+      expect(result.summary.failed).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(put2.isDone()).toBe(false);
+    });
+  });
+
   describe('getProjects', () => {
     it('sends GET /v2/projects with maxResults and startAt, returns list', async () => {
       const body = loadFixture('projects-list.json');


### PR DESCRIPTION
## Summary

The public Zephyr Scale Cloud OpenAPI does **not** define a single request that updates **multiple** test executions at once. The documented **bulk-oriented** surface for scale is **cursor-paged GET** on **`/testcases/nextgen`** and **`/testexecutions/nextgen`**. This release exposes those as MCP tools and adds **`bulk_execute_tests`**, which runs the same **`PUT /testexecutions/{id}`** contract as **`execute_test`** once per item (with optional **`continueOnError`**), matching **`create_multiple_test_cases`**.

## New MCP tools

- **`list_test_cases_nextgen`** — `GET /testcases/nextgen` (`listTestCasesCursorPaginated`). Returns `values`, `limit`, `nextStartAtId`, `next`.
- **`list_test_executions_nextgen`** — `GET /testexecutions/nextgen` (`listTestExecutionsNextgen`). Same pagination shape; supports filters from the spec (e.g. `testCycle`, `testCase`, project, dates).
- **`bulk_execute_tests`** — `{ executions: [{ executionId, status, comment?, defects? }], continueOnError? }`.

## Version

- **0.14.0** in `package.json` and MCP `version` in `src/index.ts`.

## Tests

- `tests/zephyr-client.test.ts`: nextgen GETs and `bulkExecuteTests` (success path + `continueOnError: false`).
- `npm test`, `npm run typecheck`, `npm run build` pass locally.

## Docs

- `README.md`, `CLAUDE.md`, `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` (§15 bulk operations).

## Upgrade notes

- For large **`bulk_execute_tests`** batches, consider rate limits and splitting work; nextgen list tools are preferred over repeatedly paging the non-nextgen list endpoints when pulling many rows.
