### PR TITLE
feat(ci): ESLint flat config and lint in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:unit
+      - name: Lint (ESLint)
+        run: npm run lint
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Run tests
+        run: npm run test:unit

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,51 @@
+import tseslintPlugin from '@typescript-eslint/eslint-plugin';
+
+/**
+ * ESLint flat config (ESM).
+ * - Uses @typescript-eslint's `flat/recommended` baseline.
+ * - Adds a few "best practices" rules that typically pay off quickly without
+ *   enforcing heavy type-aware constraints.
+ */
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...tseslintPlugin.configs['flat/recommended'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        Buffer: 'readonly',
+      },
+    },
+    rules: {
+      // This repo intentionally uses `any` in a few places (Axios error payloads,
+      // partially typed Zephyr responses, etc.). We keep lint coverage focused on
+      // higher-signal issues, and avoid making this rule a blocker.
+      '@typescript-eslint/no-explicit-any': 'off',
+
+      // Prevent unused variables while keeping the common convention
+      // of prefixing unused args with `_`.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+
+      // Encourage `import type` usage for type-only imports.
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
+
+      // Safer JS best practice. (Low risk for this codebase.)
+      'prefer-const': 'error',
+    },
+  },
+];
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:unit": "vitest run tests/zephyr-client.test.ts",
     "test:contract": "vitest run tests/contract",
     "test:watch": "vitest",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -53,7 +53,7 @@ export const updateTestPlanSchema = z
     labels: z.array(z.string()).optional(),
   })
   .superRefine((val, ctx) => {
-    const { planKey: _p, ...rest } = val;
+    const { planKey: _planKey, ...rest } = val;
     const hasUpdate = Object.values(rest).some(v => v !== undefined);
     if (!hasUpdate) {
       ctx.addIssue({
@@ -333,7 +333,7 @@ export const updateTestCaseSchema = z.object({
   }).optional(),
 }).refine(
   data => {
-    const { testCaseId, ...updates } = data;
+    const { testCaseId: _testCaseId, ...updates } = data;
     return Object.keys(updates).length >= 1;
   },
   { message: 'At least one field to update (name, objective, customFields, etc.) is required' }
@@ -365,7 +365,7 @@ export const updateTestStepSchema = z.object({
   index: z.number().min(1).optional(),
 }).refine(
   data => {
-    const { testCaseKey, stepId, ...updates } = data;
+    const { testCaseKey: _testCaseKey, stepId: _stepId, ...updates } = data;
     return Object.keys(updates).length >= 1;
   },
   { message: 'At least one field to update (description, expectedResult, testData, index) is required' }


### PR DESCRIPTION
## Summary

Adds ESLint 10 flat config (`eslint.config.js`), `npm run lint` / `lint:fix`, and runs lint in the existing **Test** workflow (after `npm ci`, before typecheck and unit tests).

## Changes

- **CI:** `.github/workflows/test.yml` — `npm run lint` step; order: lint → typecheck → unit tests.
- **Tooling:** TypeScript ESLint (recommended rules), `prefer-const`, `consistent-type-imports` as warn; `no-explicit-any` off for this codebase.
- **Code:** Minor `validation.ts` tweak (unused callback params prefixed with `_`) for `no-unused-vars`.

## How to verify

- Locally: `npm ci && npm run lint && npm run typecheck && npm run test:unit`
- CI: Test workflow should show a green **Lint (ESLint)** step.

## Notes

Lint currently reports **warnings** only (mostly `consistent-type-imports`); exit code remains 0. Add `--max-warnings=0` later if CI should fail on warnings.