### PR TITLE
feat(docs): Claude Agent Skill (Jira + Zephyr MCP)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Optional: `ZEPHYR_BASE_URL` (default US Scale API; **EU:** `https://eu.api.zephy
 | Doc | Use |
 |-----|-----|
 | `README.md` | User-facing tools, Docker, config |
+| `skills/jira-zephyr-mcp/SKILL.md` | Claude / Agent Skills: workflows + API conventions (MCP still required) |
 | `CLAUDE.md` (or workspace rules) | Short tool list + env + Docker note |
 | `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` | Implemented vs not, API quirks, EU/404 notes |
 | `docs/TESTING-STRATEGY.md` | Test layers and layout |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Jira Zephyr MCP Server
 
-**AI agents:** See [`AGENTS.md`](AGENTS.md) for architecture, Zephyr/Jira API conventions, token discipline, and where docs live. Claude and other tools do not load it automatically unless you add it to project instructions or context.
+**AI agents:** See [`AGENTS.md`](AGENTS.md) for architecture, Zephyr/Jira API conventions, token discipline, and where docs live. Claude and other tools do not load it automatically unless you add it to project instructions or context. For **Claude Skills**, see [`skills/jira-zephyr-mcp/SKILL.md`](skills/jira-zephyr-mcp/SKILL.md) (optional; MCP server must still be configured in the host).
 
 ## MCP Server Configuration
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ An [MCP](https://modelcontextprotocol.io/) server for JIRA and **Zephyr Scale** 
 [![Zephyr contract](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml/badge.svg)](https://github.com/miklosbagi/jira-zephyr-mcp/actions/workflows/contract.yml) · Zephyr contract (daily 6am CET / on demand).
 
 [![Docker Pulls](https://badgen.net/docker/pulls/miklosbagi/jira-zephyr-mcp?icon=docker&label=Docker%20Pulls)](https://hub.docker.com/r/miklosbagi/jira-zephyr-mcp/)
+
+### Claude skill (optional)
+
+This repo includes an [Agent Skills](https://github.com/anthropics/skills)-style package under [`skills/jira-zephyr-mcp/`](skills/jira-zephyr-mcp/). It **does not replace** the MCP server: configure **Docker or `node dist/index.js`** in your host as usual, then install the skill folder per **Claude Code** / **Claude Desktop** / **Cursor** docs (paths differ by product). The skill teaches *when and how* to use Jira/Zephyr tools safely (issue linking, EU base URL, GET-merge-PUT updates).
+
 ---
 
 ## Why this fork?

--- a/skills/jira-zephyr-mcp/SKILL.md
+++ b/skills/jira-zephyr-mcp/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: jira-zephyr-mcp
+description: >-
+  Use when working with Jira Cloud issues and Zephyr Scale test management (test plans,
+  cycles, cases, executions, coverage links) via the jira-zephyr-mcp MCP server. Apply
+  when the user mentions Zephyr, test plans/cycles, test cases, test execution, or
+  linking tests to Jira issues. Requires the MCP server to be configured in the host;
+  this skill is guidance and conventions—not a substitute for the server process.
+---
+
+# Jira + Zephyr Scale (MCP)
+
+## Prerequisites
+
+1. **MCP server running** — The host (Claude Desktop, Claude Code, Cursor, etc.) must launch `jira-zephyr-mcp` with valid env: `JIRA_BASE_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN`, `ZEPHYR_API_TOKEN`. Optional: `ZEPHYR_BASE_URL` (EU: `https://eu.api.zephyrscale.smartbear.com/v2`).
+2. **This skill** — Teaches *how* to call tools and avoid common API mistakes. It does not start HTTP or replace MCP.
+
+If tools are unavailable, tell the user to add the server per the project README (Docker Hub image or local build).
+
+## When to use which tools (overview)
+
+| Goal | Typical tools |
+|------|----------------|
+| Read Jira issue | `read_jira_issue` |
+| Zephyr projects / folders / priorities / statuses | `list_projects`, `list_folders`, `list_priorities`, `list_statuses` |
+| Test plans | `create_test_plan`, `list_test_plans`, `get_test_plan`, `update_test_plan` |
+| Test cycles | `create_test_cycle`, `list_test_cycles`, `get_test_cycle`, `update_test_cycle`, `add_test_cases_to_cycle` |
+| Executions | `create_test_execution`, `execute_test`, `bulk_execute_tests`, `list_test_executions_in_cycle`, `list_test_executions_nextgen`, `get_test_execution_status`, `remove_test_case_from_cycle`, `generate_test_report` |
+| Test cases & steps | `create_test_case`, `search_test_cases`, `list_test_cases_nextgen`, `get_test_case`, `get_test_case_links`, `update_test_case`, `archive_test_case`, `unarchive_test_case`, `delete_test_case`, `create_multiple_test_cases`, `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` |
+| Environments | `list_environments`, `get_environment`, `create_environment`, `update_environment` |
+| Coverage (Jira ↔ Zephyr) | `link_tests_to_issues`, `link_test_cycle_to_issues`, `link_test_plan_to_issues` |
+
+Prefer **listing** before **creating** when the user did not give keys/IDs. Use **cursor-paged** tools (`list_test_cases_nextgen`, `list_test_executions_nextgen`) for large result sets.
+
+## Conventions (read this before mutating)
+
+1. **Issue linking** — Zephyr expects **numeric Jira Cloud issue id** in `POST .../links/issues` bodies. The MCP tools `link_*_to_issues` accept **issue keys** and resolve them via Jira; do not invent legacy `issueKeys`-only Zephyr payloads.
+2. **Updates that need full bodies** — Test plans, cycles, cases, and environments often use **GET → merge → PUT** on the server. If an update fails with 404/405, the tenant may not expose that route—say so and suggest an alternative (e.g. archive vs delete).
+3. **Regions** — Default Zephyr API host is US; EU and others need `ZEPHYR_BASE_URL` set correctly or calls will fail or hit the wrong tenant.
+4. **Responses** — Tool results are usually JSON strings in MCP content; parse and present clearly. On `success: false`, surface the `error` field.
+
+For more detail, load `references/zephyr-jira-conventions.md` in this skill folder when debugging linking, EU/US URLs, or update semantics.
+
+## What not to do
+
+- Do not assume CodeQL, GitHub Actions, or repo CI—this skill is for **live Jira/Zephyr** via MCP.
+- Do not expose or log API tokens or paste secrets into chat.
+
+## Repository
+
+Upstream patterns and gaps: `https://github.com/miklosbagi/jira-zephyr-mcp` — see `README.md`, `AGENTS.md`, `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` for maintainers.

--- a/skills/jira-zephyr-mcp/references/zephyr-jira-conventions.md
+++ b/skills/jira-zephyr-mcp/references/zephyr-jira-conventions.md
@@ -1,0 +1,23 @@
+# Zephyr + Jira conventions (jira-zephyr-mcp)
+
+Short reference; the MCP server implements these in `src/tools/` and `src/clients/`.
+
+## Issue linking (coverage)
+
+- Zephyr Scale Cloud: `POST /testcases|testcycles|testplans/{key}/links/issues` with body **`{ "issueId": <int64> }`** (Jira Cloud numeric id).
+- Do **not** rely on undocumented legacy shapes that send only issue keys to Zephyr without resolution—those often return **405**.
+- The fork resolves Jira keys via **`GET /rest/api/3/issue/{key}`** (fields include `id`), then posts to Zephyr.
+
+## `ZEPHYR_BASE_URL`
+
+- Optional; defaults to US Scale API base.
+- **EU example:** `https://eu.api.zephyrscale.smartbear.com/v2`
+- Wrong host → auth or routing failures.
+
+## PUT / merge behavior
+
+Many updates (test cases, cycles, plans, environments) are implemented as **read existing, merge fields, write full body**. Empty or partial UI-style patches may **400** if the API requires a full entity.
+
+## MCP stdio
+
+The server uses **stdio** for JSON-RPC; stdout must remain protocol-only (no stray `console.log` in production paths). Config loading uses `dotenv` with **quiet** mode for the same reason.


### PR DESCRIPTION
## Summary

Adds an **[Agent Skills](https://github.com/anthropics/skills)-style** package at **`skills/jira-zephyr-mcp/`**:

- **`SKILL.md`** — `name` / `description` frontmatter, when to apply the skill, tool routing table, conventions (issue linking, EU `ZEPHYR_BASE_URL`, GET-merge-PUT), and explicit **MCP prerequisite**.
- **`references/zephyr-jira-conventions.md`** — short API notes for progressive disclosure.

## Docs

- **`README.md`** — optional Claude skill subsection + link.
- **`AGENTS.md`** — docs map entry.
- **`CLAUDE.md`** — pointer to the skill.

## Note

The skill **does not** run the server; users still configure Docker / `node dist/index.js` per README.