### PR TITLE
feat: v0.16 — execution links and execution test steps (MCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ The following environment variables are required:
 - `bulk_execute_tests`: Update many executions sequentially (one PUT each; no single bulk API in public spec)
 - `list_test_executions_nextgen`: Cursor-paged list of executions (`GET /testexecutions/nextgen`)
 - `get_test_execution`: Get one execution by id or key (`GET /testexecutions/{idOrKey}`, OpenAPI `getTestExecution`)
+- `get_test_execution_links`: List web links for an execution (`GET /testexecutions/{id}/links`, OpenAPI `getTestExecutionLinks`)
+- `get_test_execution_issue_links`: List Jira issue links for an execution (`GET .../links/issues`, OpenAPI `getTestExecutionIssueLinks`)
+- `get_test_execution_test_steps`: Get execution test steps (`GET .../teststeps`, OpenAPI `getTestExecutionTestSteps`)
+- `sync_test_execution_test_steps`: Sync execution steps with the test case script (`POST .../teststeps/sync`, OpenAPI `syncTestExecutionTestSteps`; optional `body`, default `{}`)
 - `get_test_execution_status`: Get test execution progress and statistics
 - `remove_test_case_from_cycle`: Remove a test case from a cycle (delete test execution by id or cycle + case key)
 - `link_tests_to_issues`: Link a test case to Jira issue(s) as coverage — `POST /testcases/{key}/links/issues` with `{ issueId }` (Jira Cloud numeric id); resolves keys via Jira REST `GET /issue/{key}` (v0.12.0)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **list_test_executions_in_cycle** | List test cases and executions in a cycle (`GET /testexecutions` with `testCycle`). |
 | **list_test_executions_nextgen** | Cursor-paged executions for large volumes ([`GET /testexecutions/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/listTestExecutionsNextgen)); use `nextStartAtId` or `next` for the next page. |
 | **get_test_execution** | Get one execution by id or key ([`GET /testexecutions/{testExecutionIdOrKey}`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecution), OpenAPI `getTestExecution`). Same row shape as **list_test_executions_in_cycle**; resolves **testCaseKey** when the API omits it (v0.15.0). |
+| **get_test_execution_links** | List web links for an execution ([`GET .../testexecutions/{id}/links`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionLinks), OpenAPI `getTestExecutionLinks`, v0.16.0). |
+| **get_test_execution_issue_links** | List Jira issue links for an execution ([`GET .../links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionIssueLinks), OpenAPI `getTestExecutionIssueLinks`, v0.16.0). |
+| **get_test_execution_test_steps** | Get execution test steps / per-step results ([`GET .../teststeps`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionTestSteps), OpenAPI `getTestExecutionTestSteps`, v0.16.0). |
+| **sync_test_execution_test_steps** | Sync execution steps with the test case script ([`POST .../teststeps/sync`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/syncTestExecutionTestSteps), OpenAPI `syncTestExecutionTestSteps`; optional `body`, default `{}`, v0.16.0). |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
 | **remove_test_case_from_cycle** | Remove a test case from a cycle by deleting its test execution (`DELETE /testexecutions/{id}`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve it. If the public API returns 404/405 on your instance, use the Zephyr UI or contact SmartBear. |
@@ -190,6 +194,10 @@ update_test_cycle({ cycleKey: "ABC-R1", name: "Sprint 10 (final)", status: "3650
 list_test_executions_in_cycle({ cycleId: "ABC-R1" });
 list_test_executions_nextgen({ testCycle: "ABC-R1", limit: 100, startAtId: 0 });  // next page: pass startAtId from nextStartAtId
 get_test_execution({ executionId: "12345" });  // or execution key from list_test_executions_in_cycle
+get_test_execution_links({ executionId: "12345" });
+get_test_execution_issue_links({ executionId: "12345" });
+get_test_execution_test_steps({ executionId: "12345" });
+sync_test_execution_test_steps({ executionId: "12345" });  // optional body: { ... } per Scale API
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
 create_test_execution({ projectKey: "ABC", testCycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
@@ -330,6 +338,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Update test plan** — **`update_test_plan`**: GET-merge-PUT; **not** listed in the public OpenAPI for `PUT /testplans/{key}` — see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 - [x] **Bulk / high-volume operations (v0.14.0)** — **`list_test_cases_nextgen`** / **`list_test_executions_nextgen`** (cursor pagination per OpenAPI). **`bulk_execute_tests`** (sequential PUTs; no single bulk endpoint in the public spec). See [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 - [x] **Get single test execution (v0.15.0)** — **`get_test_execution`**: [`GET /testexecutions/{testExecutionIdOrKey}`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecution) (OpenAPI `getTestExecution`); aligns with **list_test_executions_in_cycle** row shape and test case key enrichment ([issue #67](https://github.com/miklosbagi/jira-zephyr-mcp/issues/67)).
+- [x] **Execution links and execution test steps (v0.16.0)** — **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`** (OpenAPI `getTestExecutionLinks`, `getTestExecutionIssueLinks`, `getTestExecutionTestSteps`, `syncTestExecutionTestSteps`).
 
 ---
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -10,7 +10,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 |------|-------------|
 | **Test plans** | Create, list (by projectKey), get one, update (**`update_test_plan`**: GET-merge-PUT — **not** in public OpenAPI; see §14) |
 | **Test cycles** | Create, list (by projectKey, optional versionId), get one, **`update_test_cycle`** (PUT `testcycles/{key}`, OpenAPI `updateTestCycle`) |
-| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), update status/comment/defects, list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
+| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), **links & steps** (**`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, v0.16.0), update status/comment/defects, list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
 | **Test cases** | Get one, search, cursor list (**`list_test_cases_nextgen`**, v0.14.0), create, update, create multiple |
 | **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
 | **Priorities / statuses** | List priorities and statuses (GET /priorities, GET /statuses; optional projectKey) for test case create/update |
@@ -113,13 +113,12 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 - **API (OpenAPI):** There is **no** documented endpoint that accepts **multiple test execution updates in one request**. **`GET /testcases/nextgen`** (`listTestCasesCursorPaginated`) and **`GET /testexecutions/nextgen`** (`listTestExecutionsNextgen`) are **cursor-paged list** APIs for **large read volumes** (use `nextStartAtId` / `next` for the next page). **`POST /testcycles/{key}/testcases`** with an `items` array adds several cases to a cycle in one call — already exposed as **`add_test_cases_to_cycle`** (may 404 on some regions).
 - **MCP status (v0.14.0+):** **`list_test_cases_nextgen`** and **`list_test_executions_nextgen`** call the documented nextgen GET routes. **`bulk_execute_tests`** applies the same payload as **`execute_test`** via **sequential `PUT /testexecutions/{id}`** calls (optional **`continueOnError`**, same pattern as **`create_multiple_test_cases`**). For very large batches, prefer external orchestration or rate limits to avoid throttling.
 
-### 16. Additional test execution endpoints (not wrapped as MCP tools)
+### 16. Additional test execution endpoints (links, steps, sync)
 
 - **API:** `GET /testexecutions/{testExecutionIdOrKey}` — OpenAPI **`getTestExecution`** ([Test Executions](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions)).
 - **MCP status (v0.15.0):** Implemented as **`get_test_execution`** (`executionId`). Returns the same normalized row as **`list_test_executions_in_cycle`** (including **`testCaseKey`** / **`testCaseId`**); if GET omits **`testCase.key`** but includes a test case entity id, the server may GET **`/testcases/{id}`** to fill the key (same behaviour as issue #67 for list).
-- **API:** `GET /testexecutions/{testExecutionIdOrKey}/teststeps` and `POST /testexecutions/{testExecutionIdOrKey}/teststeps/sync` (execution step handling)
-- **API:** `GET /testexecutions/{testExecutionIdOrKey}/links` and `GET /testexecutions/{testExecutionIdOrKey}/links/issues` (execution link retrieval)
-- **MCP status:** Not exposed as MCP tools yet. **`execute_test`**, **`get_test_execution`**, creation, listing, and removal are implemented on the core execution resource.
+- **API:** `GET /testexecutions/{testExecutionIdOrKey}/links` — **`getTestExecutionLinks`**; **`GET .../links/issues`** — **`getTestExecutionIssueLinks`**; **`GET .../teststeps`** — **`getTestExecutionTestSteps`**; **`POST .../teststeps/sync`** — **`syncTestExecutionTestSteps`** (optional JSON **`body`**; defaults to **`{}`**).
+- **MCP status (v0.16.0):** Implemented as **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**. Core execution create/update/list/remove unchanged (**`execute_test`**, **`get_test_execution`**, etc.).
 
 ### 17. Web link endpoints (not wrapped as MCP tools)
 
@@ -175,7 +174,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 15 | Bulk / high-volume reads & batch execution updates | `.../nextgen` GET; no multi-execution PUT in spec | **`list_test_cases_nextgen`**, **`list_test_executions_nextgen`**; **`bulk_execute_tests`** (sequential PUTs, v0.14.0) |
 | 16 | Test case ↔ Jira issue links | GET/POST `.../links` and `.../links/issues` | Implemented (**v0.12.0**); test case, cycle, and plan issue links |
 | 17 | Single test execution retrieval | `GET /testexecutions/{idOrKey}` (`getTestExecution`) | Implemented (**`get_test_execution`**, v0.15.0) |
-| 18 | Execution links and execution test steps | `GET /testexecutions/{id}/links`, `.../teststeps`, `.../teststeps/sync` | Not exposed as MCP tools yet |
+| 18 | Execution links and execution test steps | `GET /testexecutions/{id}/links`, `.../links/issues`, `.../teststeps`, `POST .../teststeps/sync` | Implemented (**v0.16.0**): **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`** |
 | 19 | Web links on test resources | `POST .../links/weblinks` | Not exposed as MCP tools yet |
 | 20 | Plan ↔ cycle linkage | `POST /testplans/{key}/links/testcycles` | Not exposed as MCP tools yet |
 | 21 | Test case versions | `GET /testcases/{key}/versions` | Not exposed as MCP tools yet |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-zephyr-mcp",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/skills/jira-zephyr-mcp/SKILL.md
+++ b/skills/jira-zephyr-mcp/SKILL.md
@@ -25,7 +25,7 @@ If tools are unavailable, tell the user to add the server per the project README
 | Zephyr projects / folders / priorities / statuses | `list_projects`, `list_folders`, `list_priorities`, `list_statuses` |
 | Test plans | `create_test_plan`, `list_test_plans`, `get_test_plan`, `update_test_plan` |
 | Test cycles | `create_test_cycle`, `list_test_cycles`, `get_test_cycle`, `update_test_cycle`, `add_test_cases_to_cycle` |
-| Executions | `create_test_execution`, `get_test_execution`, `execute_test`, `bulk_execute_tests`, `list_test_executions_in_cycle`, `list_test_executions_nextgen`, `get_test_execution_status`, `remove_test_case_from_cycle`, `generate_test_report` |
+| Executions | `create_test_execution`, `get_test_execution`, `get_test_execution_links`, `get_test_execution_issue_links`, `get_test_execution_test_steps`, `sync_test_execution_test_steps`, `execute_test`, `bulk_execute_tests`, `list_test_executions_in_cycle`, `list_test_executions_nextgen`, `get_test_execution_status`, `remove_test_case_from_cycle`, `generate_test_report` |
 | Test cases & steps | `create_test_case`, `search_test_cases`, `list_test_cases_nextgen`, `get_test_case`, `get_test_case_links`, `update_test_case`, `archive_test_case`, `unarchive_test_case`, `delete_test_case`, `create_multiple_test_cases`, `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` |
 | Environments | `list_environments`, `get_environment`, `create_environment`, `update_environment` |
 | Coverage (Jira ↔ Zephyr) | `link_tests_to_issues`, `link_test_cycle_to_issues`, `link_test_plan_to_issues` |

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -412,6 +412,49 @@ export class ZephyrClient {
   }
 
   /**
+   * GET /testexecutions/{id}/links — web links and related link metadata for the execution.
+   * @see https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionLinks
+   */
+  async getTestExecutionLinks(executionIdOrKey: string): Promise<unknown> {
+    const id = encodeURIComponent(executionIdOrKey);
+    const response = await this.client.get(`/testexecutions/${id}/links`);
+    return response.data;
+  }
+
+  /**
+   * GET /testexecutions/{id}/links/issues — Jira issue links for the test execution.
+   * @see https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionIssueLinks
+   */
+  async getTestExecutionIssueLinks(executionIdOrKey: string): Promise<unknown> {
+    const id = encodeURIComponent(executionIdOrKey);
+    const response = await this.client.get(`/testexecutions/${id}/links/issues`);
+    return response.data;
+  }
+
+  /**
+   * GET /testexecutions/{id}/teststeps — execution test steps (per-step results).
+   * @see https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionTestSteps
+   */
+  async getTestExecutionTestSteps(executionIdOrKey: string): Promise<unknown> {
+    const id = encodeURIComponent(executionIdOrKey);
+    const response = await this.client.get(`/testexecutions/${id}/teststeps`);
+    return response.data;
+  }
+
+  /**
+   * POST /testexecutions/{id}/teststeps/sync — sync execution steps with the test case script (OpenAPI `syncTestExecutionTestSteps`).
+   * Pass an optional JSON body when your tenant requires fields beyond `{}` (see Scale API docs).
+   */
+  async syncTestExecutionTestSteps(
+    executionIdOrKey: string,
+    body?: Record<string, unknown>
+  ): Promise<unknown> {
+    const id = encodeURIComponent(executionIdOrKey);
+    const response = await this.client.post(`/testexecutions/${id}/teststeps/sync`, body ?? {});
+    return response.data;
+  }
+
+  /**
    * Remove a test case from a cycle by deleting its test execution (Scale Cloud v2:
    * DELETE /testexecutions/{id}). Some instances document this poorly; if the API returns
    * 404/405, removal may not be enabled for your tenant.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ import {
   listTestExecutionsInCycle,
   listTestExecutionsNextgen,
   getTestExecution,
+  getTestExecutionLinks,
+  getTestExecutionIssueLinks,
+  getTestExecutionTestSteps,
+  syncTestExecutionTestSteps,
   linkTestsToIssues,
   linkTestCycleToIssues,
   linkTestPlanToIssues,
@@ -55,6 +59,10 @@ import {
   executeTestSchema,
   getTestExecutionStatusSchema,
   getTestExecutionSchema,
+  getTestExecutionLinksSchema,
+  getTestExecutionIssueLinksSchema,
+  getTestExecutionTestStepsSchema,
+  syncTestExecutionTestStepsSchema,
   listTestExecutionsInCycleSchema,
   listTestExecutionsNextgenSchema,
   bulkExecuteTestsSchema,
@@ -100,6 +108,10 @@ import {
   type ExecuteTestInput,
   type GetTestExecutionStatusInput,
   type GetTestExecutionInput,
+  type GetTestExecutionLinksInput,
+  type GetTestExecutionIssueLinksInput,
+  type GetTestExecutionTestStepsInput,
+  type SyncTestExecutionTestStepsInput,
   type ListTestExecutionsInCycleInput,
   type ListTestExecutionsNextgenInput,
   type BulkExecuteTestsInput,
@@ -137,7 +149,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.15.2',
+    version: '0.16.0',
   },
   {
     capabilities: {
@@ -340,6 +352,70 @@ const TOOLS = [
         executionId: {
           type: 'string',
           description: 'Test execution id or key (e.g. numeric id or execution key from list_test_executions_in_cycle)',
+        },
+      },
+      required: ['executionId'],
+    },
+  },
+  {
+    name: 'get_test_execution_links',
+    description:
+      'List web links and related link metadata for a test execution (GET /testexecutions/{testExecutionIdOrKey}/links, OpenAPI getTestExecutionLinks).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (from list_test_executions_in_cycle or get_test_execution)',
+        },
+      },
+      required: ['executionId'],
+    },
+  },
+  {
+    name: 'get_test_execution_issue_links',
+    description:
+      'List Jira issue links for a test execution (GET /testexecutions/{testExecutionIdOrKey}/links/issues, OpenAPI getTestExecutionIssueLinks).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (from list_test_executions_in_cycle or get_test_execution)',
+        },
+      },
+      required: ['executionId'],
+    },
+  },
+  {
+    name: 'get_test_execution_test_steps',
+    description:
+      'Get execution test steps with per-step results (GET /testexecutions/{testExecutionIdOrKey}/teststeps, OpenAPI getTestExecutionTestSteps).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (from list_test_executions_in_cycle or get_test_execution)',
+        },
+      },
+      required: ['executionId'],
+    },
+  },
+  {
+    name: 'sync_test_execution_test_steps',
+    description:
+      'Sync execution test steps with the current test case script (POST /testexecutions/{testExecutionIdOrKey}/teststeps/sync, OpenAPI syncTestExecutionTestSteps). Sends an empty JSON body when omitted; pass body when your tenant requires a specific payload.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (from list_test_executions_in_cycle or get_test_execution)',
+        },
+        body: {
+          type: 'object',
+          description: 'Optional JSON body for the sync request (see Zephyr Scale API docs; defaults to {})',
         },
       },
       required: ['executionId'],
@@ -1093,6 +1169,70 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await getTestExecution(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_test_execution_links': {
+        const validatedArgs = validateInput<GetTestExecutionLinksInput>(
+          getTestExecutionLinksSchema,
+          args,
+          'get_test_execution_links'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await getTestExecutionLinks(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_test_execution_issue_links': {
+        const validatedArgs = validateInput<GetTestExecutionIssueLinksInput>(
+          getTestExecutionIssueLinksSchema,
+          args,
+          'get_test_execution_issue_links'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await getTestExecutionIssueLinks(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_test_execution_test_steps': {
+        const validatedArgs = validateInput<GetTestExecutionTestStepsInput>(
+          getTestExecutionTestStepsSchema,
+          args,
+          'get_test_execution_test_steps'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await getTestExecutionTestSteps(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'sync_test_execution_test_steps': {
+        const validatedArgs = validateInput<SyncTestExecutionTestStepsInput>(
+          syncTestExecutionTestStepsSchema,
+          args,
+          'sync_test_execution_test_steps'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await syncTestExecutionTestSteps(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-execution.ts
+++ b/src/tools/test-execution.ts
@@ -10,6 +10,10 @@ import {
   executeTestSchema,
   getTestExecutionStatusSchema,
   getTestExecutionSchema,
+  getTestExecutionLinksSchema,
+  getTestExecutionIssueLinksSchema,
+  getTestExecutionTestStepsSchema,
+  syncTestExecutionTestStepsSchema,
   listTestExecutionsInCycleSchema,
   listTestExecutionsNextgenSchema,
   bulkExecuteTestsSchema,
@@ -22,6 +26,10 @@ import {
   type ExecuteTestInput,
   type GetTestExecutionStatusInput,
   type GetTestExecutionInput,
+  type GetTestExecutionLinksInput,
+  type GetTestExecutionIssueLinksInput,
+  type GetTestExecutionTestStepsInput,
+  type SyncTestExecutionTestStepsInput,
   type ListTestExecutionsInCycleInput,
   type ListTestExecutionsNextgenInput,
   type BulkExecuteTestsInput,
@@ -237,6 +245,49 @@ export const getTestExecution = async (input: GetTestExecutionInput) => {
     };
   } catch (error: unknown) {
     return zephyrToolFailure(error, { permissionCategories: [] });
+  }
+};
+
+export const getTestExecutionLinks = async (input: GetTestExecutionLinksInput) => {
+  const validatedInput = getTestExecutionLinksSchema.parse(input);
+  try {
+    const data = await getZephyrClient().getTestExecutionLinks(validatedInput.executionId.trim());
+    return { success: true, data };
+  } catch (error: unknown) {
+    return zephyrToolFailure(error, { permissionCategories: [] });
+  }
+};
+
+export const getTestExecutionIssueLinks = async (input: GetTestExecutionIssueLinksInput) => {
+  const validatedInput = getTestExecutionIssueLinksSchema.parse(input);
+  try {
+    const data = await getZephyrClient().getTestExecutionIssueLinks(validatedInput.executionId.trim());
+    return { success: true, data };
+  } catch (error: unknown) {
+    return zephyrToolFailure(error, { permissionCategories: [] });
+  }
+};
+
+export const getTestExecutionTestSteps = async (input: GetTestExecutionTestStepsInput) => {
+  const validatedInput = getTestExecutionTestStepsSchema.parse(input);
+  try {
+    const data = await getZephyrClient().getTestExecutionTestSteps(validatedInput.executionId.trim());
+    return { success: true, data };
+  } catch (error: unknown) {
+    return zephyrToolFailure(error, { permissionCategories: [] });
+  }
+};
+
+export const syncTestExecutionTestSteps = async (input: SyncTestExecutionTestStepsInput) => {
+  const validatedInput = syncTestExecutionTestStepsSchema.parse(input);
+  try {
+    const data = await getZephyrClient().syncTestExecutionTestSteps(
+      validatedInput.executionId.trim(),
+      validatedInput.body
+    );
+    return { success: true, data };
+  } catch (error: unknown) {
+    return zephyrToolFailure(error, { permissionCategories: ['edit'] });
   }
 };
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -103,6 +103,27 @@ export const getTestExecutionSchema = z.object({
   executionId: z.string().min(1, 'Test execution id or key is required'),
 });
 
+/** GET /testexecutions/{idOrKey}/links — OpenAPI `getTestExecutionLinks`. */
+export const getTestExecutionLinksSchema = z.object({
+  executionId: z.string().min(1, 'Test execution id or key is required'),
+});
+
+/** GET /testexecutions/{idOrKey}/links/issues — OpenAPI `getTestExecutionIssueLinks`. */
+export const getTestExecutionIssueLinksSchema = z.object({
+  executionId: z.string().min(1, 'Test execution id or key is required'),
+});
+
+/** GET /testexecutions/{idOrKey}/teststeps — OpenAPI `getTestExecutionTestSteps`. */
+export const getTestExecutionTestStepsSchema = z.object({
+  executionId: z.string().min(1, 'Test execution id or key is required'),
+});
+
+/** POST /testexecutions/{idOrKey}/teststeps/sync — OpenAPI `syncTestExecutionTestSteps`. */
+export const syncTestExecutionTestStepsSchema = z.object({
+  executionId: z.string().min(1, 'Test execution id or key is required'),
+  body: z.record(z.string(), z.any()).optional(),
+});
+
 export const listTestExecutionsInCycleSchema = z.object({
   cycleId: z.string().min(1, 'Cycle ID or key is required'),
 });
@@ -394,6 +415,10 @@ export type UpdateTestCycleInput = z.infer<typeof updateTestCycleSchema>;
 export type ExecuteTestInput = z.infer<typeof executeTestSchema>;
 export type GetTestExecutionStatusInput = z.infer<typeof getTestExecutionStatusSchema>;
 export type GetTestExecutionInput = z.infer<typeof getTestExecutionSchema>;
+export type GetTestExecutionLinksInput = z.infer<typeof getTestExecutionLinksSchema>;
+export type GetTestExecutionIssueLinksInput = z.infer<typeof getTestExecutionIssueLinksSchema>;
+export type GetTestExecutionTestStepsInput = z.infer<typeof getTestExecutionTestStepsSchema>;
+export type SyncTestExecutionTestStepsInput = z.infer<typeof syncTestExecutionTestStepsSchema>;
 export type ListTestExecutionsInCycleInput = z.infer<typeof listTestExecutionsInCycleSchema>;
 export type ListTestExecutionsNextgenInput = z.infer<typeof listTestExecutionsNextgenSchema>;
 export type ListTestCasesNextgenInput = z.infer<typeof listTestCasesNextgenSchema>;

--- a/tests/tools-handlers.test.ts
+++ b/tests/tools-handlers.test.ts
@@ -29,6 +29,10 @@ import {
   listTestExecutionsInCycle,
   listTestExecutionsNextgen,
   getTestExecution,
+  getTestExecutionLinks,
+  getTestExecutionIssueLinks,
+  getTestExecutionTestSteps,
+  syncTestExecutionTestSteps,
   bulkExecuteTests,
   generateTestReport,
   createTestExecution,
@@ -634,6 +638,69 @@ describe('tool handlers (smoke, mocked)', () => {
     if (!r.success) {
       expect(r.error).toBe('unexpected bulk failure');
     }
+  });
+
+  it('get_test_execution_links returns raw links payload', async () => {
+    const payload = { issueLinks: [], webLinks: [] };
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/e-links/links`).reply(200, payload);
+    const r = await getTestExecutionLinks({ executionId: 'e-links' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(payload);
+  });
+
+  it('get_test_execution_issue_links returns issue links payload', async () => {
+    const payload = { issues: [{ issueId: 42 }] };
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/e-iss/links/issues`).reply(200, payload);
+    const r = await getTestExecutionIssueLinks({ executionId: 'e-iss' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(payload);
+  });
+
+  it('get_test_execution_issue_links returns error when Zephyr fails', async () => {
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/missing/links/issues`).reply(404, { message: 'nope' });
+    const r = await getTestExecutionIssueLinks({ executionId: 'missing' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.errorInfo?.kind).toBe('not_found');
+  });
+
+  it('get_test_execution_links returns error when Zephyr fails', async () => {
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/bad-ex/links`).reply(500, { message: 'server' });
+    const r = await getTestExecutionLinks({ executionId: 'bad-ex' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.errorInfo?.kind).toBe('server_error');
+  });
+
+  it('get_test_execution_test_steps returns error when Zephyr fails', async () => {
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/x/teststeps`).reply(403, { message: 'forbidden' });
+    const r = await getTestExecutionTestSteps({ executionId: 'x' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.errorInfo?.kind).toBe('permission_denied');
+  });
+
+  it('sync_test_execution_test_steps returns error when Zephyr fails', async () => {
+    nock(ZEPHYR_ORIGIN)
+      .post(`${V2}/testexecutions/bad-sync/teststeps/sync`, () => true)
+      .reply(400, { message: 'bad request' });
+    const r = await syncTestExecutionTestSteps({ executionId: 'bad-sync' });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.errorInfo?.kind).toBe('validation');
+  });
+
+  it('get_test_execution_test_steps returns execution steps', async () => {
+    const payload = { values: [{ index: 1 }] };
+    nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/ex-1/teststeps`).reply(200, payload);
+    const r = await getTestExecutionTestSteps({ executionId: 'ex-1' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(payload);
+  });
+
+  it('sync_test_execution_test_steps posts sync', async () => {
+    nock(ZEPHYR_ORIGIN)
+      .post(`${V2}/testexecutions/ex-sync/teststeps/sync`, (b: Record<string, unknown>) => Object.keys(b).length === 0)
+      .reply(200, { done: true });
+    const r = await syncTestExecutionTestSteps({ executionId: 'ex-sync' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual({ done: true });
   });
 
   it('get_test_execution returns a single execution row', async () => {

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -769,6 +769,54 @@ describe('ZephyrClient (integration, mocked)', () => {
     });
   });
 
+  describe('getTestExecutionLinks / getTestExecutionIssueLinks / getTestExecutionTestSteps / syncTestExecutionTestSteps', () => {
+    it('sends GET /v2/testexecutions/{id}/links', async () => {
+      const body = { issueLinks: [], webLinks: [] };
+      const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/e-1/links`).reply(200, body);
+      await expect(client.getTestExecutionLinks('e-1')).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('sends GET /v2/testexecutions/{id}/links/issues', async () => {
+      const body = { issues: [{ issueId: 1 }] };
+      const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/e-2/links/issues`).reply(200, body);
+      await expect(client.getTestExecutionIssueLinks('e-2')).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('sends GET /v2/testexecutions/{id}/teststeps', async () => {
+      const body = { values: [{ index: 1, status: 'PASS' }] };
+      const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/99/teststeps`).reply(200, body);
+      await expect(client.getTestExecutionTestSteps('99')).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('sends POST /v2/testexecutions/{id}/teststeps/sync with empty body by default', async () => {
+      const body = { synced: true };
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/testexecutions/e-sync/teststeps/sync`, (b: Record<string, unknown>) => Object.keys(b).length === 0)
+        .reply(200, body);
+      await expect(client.syncTestExecutionTestSteps('e-sync')).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('sends POST /v2/testexecutions/{id}/teststeps/sync with custom body', async () => {
+      const body = { ok: true };
+      const scope = nock(ZEPHYR_ORIGIN)
+        .post(`${V2}/testexecutions/e-sync/teststeps/sync`, (b: Record<string, unknown>) => (b as { mode?: string }).mode === 'FULL')
+        .reply(200, body);
+      await expect(client.syncTestExecutionTestSteps('e-sync', { mode: 'FULL' })).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('encodes execution id in path segments', async () => {
+      const encoded = encodeURIComponent('E/1');
+      const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/${encoded}/links`).reply(200, {});
+      await client.getTestExecutionLinks('E/1');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
   describe('getTestExecutionSummary', () => {
     it('aggregates statuses across branches', async () => {
       const values = [


### PR DESCRIPTION
## Summary

This release adds four MCP tools that wrap the Zephyr Scale Cloud v2 test execution endpoints for **links**, **issue links**, **test steps**, and **step sync**, as listed in `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` (summary row #18). Server and package version are bumped to **0.16.0**.

## New MCP tools

| Tool | API |
|------|-----|
| `get_test_execution_links` | `GET /testexecutions/{id}/links` |
| `get_test_execution_issue_links` | `GET /testexecutions/{id}/links/issues` |
| `get_test_execution_test_steps` | `GET /testexecutions/{id}/teststeps` |
| `sync_test_execution_test_steps` | `POST /testexecutions/{id}/teststeps/sync` (optional JSON `body`; defaults to `{}`) |

All paths use the same id/key encoding as `get_test_execution`.

## Implementation notes

- **Client:** `ZephyrClient` methods in `src/clients/zephyr-client.ts`.
- **Handlers:** `src/tools/test-execution.ts` with Zod validation in `src/utils/validation.ts`.
- **Wiring:** `src/index.ts` (`TOOLS` + `CallTool`).
- **Tests:** `tests/zephyr-client.test.ts` (request shape), `tests/tools-handlers.test.ts` (success and error paths). `npm run test:coverage` passes with existing thresholds.

## Documentation

- `README.md`, `CLAUDE.md`, `skills/jira-zephyr-mcp/SKILL.md` — tool list and examples.
- `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` — §16 and summary table #18 updated to **implemented (v0.16.0)**.

## How to verify

1. `npm run lint && npm run typecheck && npm run test:coverage && npm run build`
2. With a running MCP config, call the new tools with an `executionId` from `list_test_executions_in_cycle` or `get_test_execution`.

## Upgrade notes

- No breaking changes. Consumers only need the new server build/image for the additional tools.
- If `sync_test_execution_test_steps` fails on your tenant, check SmartBear’s OpenAPI for `syncTestExecutionTestSteps` — pass a **`body`** object if the API requires fields beyond `{}`.