### PR TITLE
release: v0.16.1 (ip-address 10.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2645,10 +2645,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3022,7 +3024,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.16.0',
+    version: '0.16.1',
   },
   {
     capabilities: {


### PR DESCRIPTION
## Summary

Patch release **0.16.1** incorporating the Dependabot update that could not be merged earlier as [PR #108](https://github.com/miklosbagi/jira-zephyr-mcp/pull/108) (indirect dependency **ip-address** 10.1.0 → 10.2.0). Rebasing/merging onto current `main` passes the full quality gate locally.

## Fixes

- Refresh transitive **ip-address** via `package-lock.json` (security/maintenance).

## New MCP tools

- None.

## Tests

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run build`

## Upgrade notes

- No API or tool changes; bump **0.16.0** → **0.16.1** for Docker/tags only if you pin by patch version.