### PR TITLE
docs: attachment limitation (#118) and execution status gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Optional: `ZEPHYR_BASE_URL` (default US Scale API; **EU:** `https://eu.api.zephy
 - **Zephyr issue linking (coverage):** `POST /testcases|testcycles|testplans/{key}/links/issues` with body **`{ "issueId": <int64> }`** (Jira Cloud numeric issue id). **Do not** use legacy `POST .../links` + `issueKeys` (often **405**).
 - Resolve keys: Jira **`GET /rest/api/3/issue/{key}`** (fields can include `id`), then POST to Zephyr.
 - **PUT** endpoints often need **full merged bodies** after GET (test cases, cycles, environments) — see existing client methods.
+- **Attachments:** No public Scale Cloud v2 routes — do not implement private TM4J/S3 flows without explicit request ([issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118); gaps doc §22).
+- **Execution status:** `execute_test` uses `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`. Per-step results: OpenAPI `PUT .../teststeps` not in MCP yet (gaps doc §23).
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ The following environment variables are required:
 - `archive_test_case` / `unarchive_test_case` / `delete_test_case`: Archive, unarchive, or delete a test case (API support varies by tenant)
 - `list_environments` / `get_environment` / `create_environment` / `update_environment`: List and manage Zephyr test environments per project
 
+### Known limitations
+
+- **Attachments:** No upload/download tools — public Scale Cloud API has no attachment routes ([issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118); see `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` §22).
+- **Per-step execution results:** `get_test_execution_test_steps` / `sync_test_execution_test_steps` only; `PUT /testexecutions/{id}/teststeps` not exposed yet. Use `execute_test` with `WIP` (In progress), `PASS`, `FAIL`, or `BLOCKED` for whole-execution status.
+
 ### Setup Instructions
 
 1. Build the project: `npm run build`

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **create_test_case** / **search_test_cases** / **list_test_cases_nextgen** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, cursor list ([`GET /testcases/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/listTestCasesCursorPaginated)), get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
 | **archive_test_case** / **unarchive_test_case** / **delete_test_case** | Archive via PUT (`archived` flag), unarchive, or DELETE. **API support varies** — some instances reject `archived` or DELETE; see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md). |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
-| **execute_test** | Update one test execution status (PASS/FAIL/WIP/BLOCKED). |
+| **execute_test** | Update one test execution status: **`PASS`**, **`FAIL`**, **`WIP`** (In progress), or **`BLOCKED`** via `PUT /testexecutions/{id}`. Use **`WIP`** to move from Not executed to In progress. |
 | **bulk_execute_tests** | Update many executions **sequentially** (one `PUT /testexecutions/{id}` per item). The public API has **no** single bulk-update call; optional `continueOnError` (default true), same idea as `create_multiple_test_cases`. |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
 | **link_tests_to_issues** | Link a test case to Jira issue(s) as **coverage** ([`POST .../testcases/{key}/links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/createTestCaseIssueLink)). Resolves each issue **key** to a numeric id via Jira REST, then calls Zephyr (v0.12.0; replaces the old `POST .../links` + `issueKeys` shape). |
@@ -161,6 +161,17 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **generate_test_report** | Generate cycle report (JSON or HTML). |
 
 **Zephyr tool failures (v0.15.1+):** When a Zephyr-backed tool returns `success: false`, the JSON includes **`errorInfo`**: `httpStatus`, **`kind`** (e.g. `permission_denied`, `validation`, `not_found`), **`permissionIssueLikely`**, **`relevantPermissionCategories`** (aligned with Zephyr UI buckets: Create, Edit, Archive, Manage Folders, Create Versions, Delete), optional **`hint`**, and **`integration`** (`zephyr` vs `jira` on issue-link steps). The top-level **`error`** string matches **`errorInfo.message`** (typically `HTTP <status>: …` when the API returned a status).
+
+## Known limitations
+
+Documented gaps between Zephyr Scale Cloud and this MCP server. Full detail: [docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
+
+| Topic | MCP today | Notes |
+|-------|-----------|--------|
+| **Attachments** (screenshots, GIFs, evidence) | No tools | Public Scale API v2 has no attachment upload/download routes on Cloud. [Issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118). Workarounds: Jira issue attachments on linked defects; URLs in execution comments; UI upload. |
+| **Per-step Pass/Fail on executions** | Read-only + sync | **`get_test_execution_test_steps`** reads step results; **`sync_test_execution_test_steps`** refreshes steps from the test case script. **`PUT /testexecutions/{id}/teststeps`** (`putTestExecutionTestSteps`) is **not** wrapped yet — use **`execute_test`** for whole-execution status only. |
+| **Execution status** | **`execute_test`** | **`WIP`** = In progress. **`PASS`** / **`FAIL`** / **`BLOCKED`** for final states. Cannot set back to Not executed via API update. |
+| **BDD script type** | Plain text / step-by-step only | BDD (Gherkin) requires UI or unsupported TM4J backend — see gaps doc §11b. |
 
 ---
 
@@ -339,6 +350,8 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Bulk / high-volume operations (v0.14.0)** — **`list_test_cases_nextgen`** / **`list_test_executions_nextgen`** (cursor pagination per OpenAPI). **`bulk_execute_tests`** (sequential PUTs; no single bulk endpoint in the public spec). See [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 - [x] **Get single test execution (v0.15.0)** — **`get_test_execution`**: [`GET /testexecutions/{testExecutionIdOrKey}`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecution) (OpenAPI `getTestExecution`); aligns with **list_test_executions_in_cycle** row shape and test case key enrichment ([issue #67](https://github.com/miklosbagi/jira-zephyr-mcp/issues/67)).
 - [x] **Execution links and execution test steps (v0.16.0)** — **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`** (OpenAPI `getTestExecutionLinks`, `getTestExecutionIssueLinks`, `getTestExecutionTestSteps`, `syncTestExecutionTestSteps`).
+- [ ] **Attachments on test cases / executions** — blocked: no public Cloud API ([issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118); [SmartBear/smartbear-mcp#456](https://github.com/SmartBear/smartbear-mcp/issues/456)).
+- [ ] **Update execution step results** — `PUT /testexecutions/{id}/teststeps` (`putTestExecutionTestSteps`); whole-execution **`execute_test`** (`WIP` = In progress) exists today.
 
 ---
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -151,6 +151,20 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 - **API (OpenAPI):** `GET/POST /automations/testcases/...` (automation operations for test cases)
 - **MCP status:** Not implemented as MCP tools yet.
 
+### 22. **Attachments (upload / download evidence)**
+
+- **API (public Scale Cloud v2):** No documented **`POST`/`GET`** attachment routes on test cases, test executions, or execution steps in the [OpenAPI spec](https://support.smartbear.com/zephyr-scale-cloud/api-docs/). Server/DC paths (e.g. `POST /rest/atm/1.0/testresult/{id}/attachments`) do **not** apply to Cloud tenants.
+- **MCP status:** **Not implemented** — blocked on upstream API support. Tracked as [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118).
+- **SmartBear / community:** Support repeatedly states Cloud attachment upload/download is **UI-only** via the public REST API — e.g. [Cloud API: Uploading an attachment to a test result](https://community.smartbear.com/discussions/zephyrscale/cloud-api-uploading-an-attachment-to-a-test-result/210086), [How to upload an attachment file to a test execution via REST API?](https://community.smartbear.com/discussions/zephyrscale/how-to-upload-an-attachment-file-to-a-test-execution-via-zephyr-scale-cloud-rest/277229), [accessing images](https://community.smartbear.com/discussions/zephyrscale/accessing-images/260279) (CloudFront URLs need session JWT, not the Scale API token). Upstream: [SmartBear/smartbear-mcp#456](https://github.com/SmartBear/smartbear-mcp/issues/456) (official attachment endpoints planned).
+- **Undocumented private TM4J backend:** The UI uses `app.tm4j.smartbear.com/backend/rest/tests/2.0/` with **Context JWT** (Jira Basic auth) + S3 upload — see community package [`@rbaileysr/zephyr-managed-api`](https://www.npmjs.com/package/@rbaileysr/zephyr-managed-api). Same auth/tenant problems as BDD via TM4J (§11b). **Not** planned for this MCP without explicit opt-in.
+- **Workarounds:** Jira issue attachments on linked defects (`POST /rest/api/3/issue/{key}/attachments`); artifact URLs in execution **comments**; manual upload in the Zephyr UI.
+
+### 23. **Update execution step results (per-step Pass / Fail / In progress)**
+
+- **API (OpenAPI):** **`PUT /testexecutions/{testExecutionIdOrKey}/teststeps`** — OpenAPI **`putTestExecutionTestSteps`**. Body: `{ "steps": [ { "statusName": "Pass" \| "Fail" \| …, "actualResult": "…" }, … ] }` — array index matches step order; only provided fields are updated ([SmartBear/smartbear-mcp](https://github.com/SmartBear/smartbear-mcp) documents this operation).
+- **MCP status:** **Not implemented** as a tool yet. **`get_test_execution_test_steps`** (GET) and **`sync_test_execution_test_steps`** (POST sync with test case script) are implemented (v0.16.0); they do **not** set per-step status.
+- **Whole-execution status:** **`execute_test`** / **`bulk_execute_tests`** use **`PUT /testexecutions/{id}`** with `status`: **`PASS`**, **`FAIL`**, **`WIP`** (maps to **In progress** in reports), or **`BLOCKED`**. Use **`WIP`** to move from **Not executed** to **In progress**. There is no `NOT_EXECUTED` value on update — initial state comes from **`create_test_execution`** (`statusName: "Not Executed"`).
+
 ---
 
 ## Summary table
@@ -180,6 +194,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 21 | Test case versions | `GET /testcases/{key}/versions` | Not exposed as MCP tools yet |
 | 22 | Per-id GETs and link retrieval | `GET /folders/{id}`, `GET /projects/{idOrKey}`, `GET /links/{linkId}` | Not exposed as MCP tools yet |
 | 23 | Test case automations | `/automations/testcases/...` | Not exposed as MCP tools yet |
+| 24 | Attachments (evidence files) | None in public OpenAPI | **Not implemented** — [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118); wait for official Cloud API |
+| 25 | Per-step execution results | `PUT /testexecutions/{id}/teststeps` (`putTestExecutionTestSteps`) | **Not exposed**; whole-execution **`execute_test`** (`PASS`/`FAIL`/`WIP`/`BLOCKED`) is implemented |
 
 ---
 
@@ -202,6 +218,12 @@ These are limitations or bugs we have confirmed and for which we have references
 - **Observed:** When creating a test case with step-by-step script, a post-create call to add steps using the documented bulk shape fails. Sending `POST /testcases/{key}/teststeps` with `{ mode: "APPEND", items: [ { inline: { description, testData, expectedResult }, testCase: { testCaseKey, self } } ] }` returns **400** with message like **`createTestCaseTestSteps: must not be null`** (US) or **`createTestCaseTestSteps.mode: must not be null`** (EU). Wrapping in `{ createTestCaseTestSteps: { mode, items } }` does not resolve it on EU.
 - **Community evidence:** [Test to write to Zephyr Scale – createTestCaseTestSteps: must not be null](https://community.smartbear.com/discussions/zephyrscale/test-to-write-to-zphyr-scales--errorcode400messagecreatetestcaseteststeps-must-n/235621) — same payload and same error (bulk with `mode` and `items`).
 - **Workaround:** Add steps **one at a time** with a **flat** body per step: `POST /testcases/{key}/teststeps` with `{ description, expectedResult, testData }` (or `step` / `result` / `data`). The MCP server uses this single-step contract for `create_test_step` and for the step-by-step fallback after create.
+
+### Attachments cannot be uploaded or downloaded via the public Scale Cloud API
+
+- **Conclusion:** Zephyr Scale Cloud has **no supported public REST API** for uploading or downloading attachments (screenshots, GIFs, PDFs) on test cases or test executions. The MCP server has **no attachment tools**.
+- **GitHub:** [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118) — full references, private TM4J/S3 reverse-engineering notes, and workarounds.
+- **When to implement:** After SmartBear documents stable Cloud **`POST`/`GET`** attachment endpoints ([smartbear-mcp#456](https://github.com/SmartBear/smartbear-mcp/issues/456)).
 
 ---
 

--- a/skills/jira-zephyr-mcp/SKILL.md
+++ b/skills/jira-zephyr-mcp/SKILL.md
@@ -39,6 +39,17 @@ Prefer **listing** before **creating** when the user did not give keys/IDs. Use 
 3. **Regions** — Default Zephyr API host is US; EU and others need `ZEPHYR_BASE_URL` set correctly or calls will fail or hit the wrong tenant.
 4. **Responses** — Tool results are usually JSON strings in MCP content; parse and present clearly. On `success: false`, surface the `error` field.
 
+## Known limitations (agents)
+
+| Need | Use instead |
+|------|-------------|
+| Upload screenshot/GIF evidence to a test execution | **Not supported** — [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118). Attach to linked Jira defects or put artifact URLs in `execute_test` **comment**. |
+| Mark execution **In progress** from Not executed | **`execute_test`** with **`status: "WIP"`** (same as In progress in Zephyr). |
+| Set each **step** to Pass/Fail | **Not in MCP yet** — API is `PUT /testexecutions/{id}/teststeps`; today only **`get_test_execution_test_steps`** (read) and **`execute_test`** (whole case). |
+| Set execution back to Not executed | **Not via `execute_test`** — only `PASS` / `FAIL` / `WIP` / `BLOCKED` on update. |
+
+See `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` §22–§23.
+
 For more detail, load `references/zephyr-jira-conventions.md` in this skill folder when debugging linking, EU/US URLs, or update semantics.
 
 ## What not to do


### PR DESCRIPTION
## Summary

- Documents the **attachment upload/download limitation** on Zephyr Scale Cloud across repo markdown (links [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118)).
- Adds **execution status** and **per-step result** guidance: `execute_test` with `WIP` for In progress; `PUT /testexecutions/{id}/teststeps` not yet exposed as an MCP tool.

## Files

| File | Change |
|------|--------|
| `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md` | §22 attachments, §23 execution step updates, summary rows #24–#25, known-issues entry |
| `README.md` | New **Known limitations** table; roadmap items for attachments + step PUT |
| `CLAUDE.md` | Short known-limitations subsection |
| `AGENTS.md` | API convention bullets for agents |
| `skills/jira-zephyr-mcp/SKILL.md` | Agent-oriented limitations table |

## Test plan

- [x] Docs-only change — no code or tests required
- [ ] Review links to #118 and gaps doc sections render correctly on GitHub