### PR TITLE
feat: update_test_execution_test_steps — v0.17.0 (tag-minor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ The following environment variables are required:
 - `get_test_execution_issue_links`: List Jira issue links for an execution (`GET .../links/issues`, OpenAPI `getTestExecutionIssueLinks`)
 - `get_test_execution_test_steps`: Get execution test steps (`GET .../teststeps`, OpenAPI `getTestExecutionTestSteps`)
 - `sync_test_execution_test_steps`: Sync execution steps with the test case script (`POST .../teststeps/sync`, OpenAPI `syncTestExecutionTestSteps`; optional `body`, default `{}`)
+- `update_test_execution_test_steps`: Update per-step execution results (`PUT .../teststeps`, OpenAPI `putTestExecutionTestSteps`; `steps` array by index)
 - `get_test_execution_status`: Get test execution progress and statistics
 - `remove_test_case_from_cycle`: Remove a test case from a cycle (delete test execution by id or cycle + case key)
 - `link_tests_to_issues`: Link a test case to Jira issue(s) as coverage — `POST /testcases/{key}/links/issues` with `{ issueId }` (Jira Cloud numeric id); resolves keys via Jira REST `GET /issue/{key}` (v0.12.0)

--- a/README.md
+++ b/README.md
@@ -145,13 +145,14 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **get_test_execution_issue_links** | List Jira issue links for an execution ([`GET .../links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionIssueLinks), OpenAPI `getTestExecutionIssueLinks`, v0.16.0). |
 | **get_test_execution_test_steps** | Get execution test steps / per-step results ([`GET .../teststeps`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecutionTestSteps), OpenAPI `getTestExecutionTestSteps`, v0.16.0). |
 | **sync_test_execution_test_steps** | Sync execution steps with the test case script ([`POST .../teststeps/sync`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/syncTestExecutionTestSteps), OpenAPI `syncTestExecutionTestSteps`; optional `body`, default `{}`, v0.16.0). |
+| **update_test_execution_test_steps** | Update per-step Pass/Fail and results ([`PUT .../teststeps`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/putTestExecutionTestSteps), OpenAPI `putTestExecutionTestSteps`; `steps` array by index, v0.17.0). |
 | **add_test_cases_to_cycle** | Add existing test cases to a test cycle (by cycle key and test case keys). On **EU API** this endpoint often returns 404; use **create_test_execution** instead (one call per test case, status “Not Executed”). |
 | **create_test_execution** | Create a test execution (add a test case to a cycle). Use when `add_test_cases_to_cycle` returns 404 (e.g. EU). One call per test case; default status “Not Executed” mimics adding via UI. |
 | **remove_test_case_from_cycle** | Remove a test case from a cycle by deleting its test execution (`DELETE /testexecutions/{id}`). Pass **`executionId`** from `list_test_executions_in_cycle`, or **`cycleKey` + `testCaseKey`** to resolve it. If the public API returns 404/405 on your instance, use the Zephyr UI or contact SmartBear. |
 | **create_test_case** / **search_test_cases** / **list_test_cases_nextgen** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, cursor list ([`GET /testcases/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/listTestCasesCursorPaginated)), get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
 | **archive_test_case** / **unarchive_test_case** / **delete_test_case** | Archive via PUT (`archived` flag), unarchive, or DELETE. **API support varies** — some instances reject `archived` or DELETE; see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md). |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
-| **execute_test** | Update one test execution status (PASS/FAIL/WIP/BLOCKED). |
+| **execute_test** | Update one test execution status: **`PASS`**, **`FAIL`**, **`WIP`** (In progress), or **`BLOCKED`** via `PUT /testexecutions/{id}`. |
 | **bulk_execute_tests** | Update many executions **sequentially** (one `PUT /testexecutions/{id}` per item). The public API has **no** single bulk-update call; optional `continueOnError` (default true), same idea as `create_multiple_test_cases`. |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
 | **link_tests_to_issues** | Link a test case to Jira issue(s) as **coverage** ([`POST .../testcases/{key}/links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/createTestCaseIssueLink)). Resolves each issue **key** to a numeric id via Jira REST, then calls Zephyr (v0.12.0; replaces the old `POST .../links` + `issueKeys` shape). |
@@ -198,6 +199,14 @@ get_test_execution_links({ executionId: "12345" });
 get_test_execution_issue_links({ executionId: "12345" });
 get_test_execution_test_steps({ executionId: "12345" });
 sync_test_execution_test_steps({ executionId: "12345" });  // optional body: { ... } per Scale API
+update_test_execution_test_steps({
+  executionId: "12345",
+  steps: [
+    { statusName: "Pass", actualResult: "Step 1 ok" },
+    { statusName: "Fail", actualResult: "Step 2 failed" },
+  ],
+});
+execute_test({ executionId: "12345", status: "WIP" });  // In progress
 add_test_cases_to_cycle({ cycleKey: "ABC-R1", testCaseKeys: ["ABC-T1", "ABC-T2"] });
 // If add_test_cases_to_cycle returns 404 (e.g. EU API), use create_test_execution per test case:
 create_test_execution({ projectKey: "ABC", testCycleKey: "ABC-R1", testCaseKey: "ABC-T1" });
@@ -339,6 +348,7 @@ Planned additions (no dates; order may change). Based on [Zephyr Scale Cloud API
 - [x] **Bulk / high-volume operations (v0.14.0)** — **`list_test_cases_nextgen`** / **`list_test_executions_nextgen`** (cursor pagination per OpenAPI). **`bulk_execute_tests`** (sequential PUTs; no single bulk endpoint in the public spec). See [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md).
 - [x] **Get single test execution (v0.15.0)** — **`get_test_execution`**: [`GET /testexecutions/{testExecutionIdOrKey}`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/getTestExecution) (OpenAPI `getTestExecution`); aligns with **list_test_executions_in_cycle** row shape and test case key enrichment ([issue #67](https://github.com/miklosbagi/jira-zephyr-mcp/issues/67)).
 - [x] **Execution links and execution test steps (v0.16.0)** — **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`** (OpenAPI `getTestExecutionLinks`, `getTestExecutionIssueLinks`, `getTestExecutionTestSteps`, `syncTestExecutionTestSteps`).
+- [x] **Update execution step results (v0.17.0)** — **`update_test_execution_test_steps`**: [`PUT /testexecutions/{id}/teststeps`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions/operation/putTestExecutionTestSteps) (`putTestExecutionTestSteps`).
 
 ---
 

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -10,7 +10,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 |------|-------------|
 | **Test plans** | Create, list (by projectKey), get one, update (**`update_test_plan`**: GET-merge-PUT — **not** in public OpenAPI; see §14) |
 | **Test cycles** | Create, list (by projectKey, optional versionId), get one, **`update_test_cycle`** (PUT `testcycles/{key}`, OpenAPI `updateTestCycle`) |
-| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), **links & steps** (**`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, v0.16.0), update status/comment/defects, list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
+| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), **links & steps** (**`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, **`update_test_execution_test_steps`**, v0.16.0–v0.17.0), update status/comment/defects (**`execute_test`**: `PASS`/`FAIL`/`WIP`/In progress/`BLOCKED`), list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
 | **Test cases** | Get one, search, cursor list (**`list_test_cases_nextgen`**, v0.14.0), create, update, create multiple |
 | **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
 | **Priorities / statuses** | List priorities and statuses (GET /priorities, GET /statuses; optional projectKey) for test case create/update |
@@ -117,8 +117,8 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 
 - **API:** `GET /testexecutions/{testExecutionIdOrKey}` — OpenAPI **`getTestExecution`** ([Test Executions](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Executions)).
 - **MCP status (v0.15.0):** Implemented as **`get_test_execution`** (`executionId`). Returns the same normalized row as **`list_test_executions_in_cycle`** (including **`testCaseKey`** / **`testCaseId`**); if GET omits **`testCase.key`** but includes a test case entity id, the server may GET **`/testcases/{id}`** to fill the key (same behaviour as issue #67 for list).
-- **API:** `GET /testexecutions/{testExecutionIdOrKey}/links` — **`getTestExecutionLinks`**; **`GET .../links/issues`** — **`getTestExecutionIssueLinks`**; **`GET .../teststeps`** — **`getTestExecutionTestSteps`**; **`POST .../teststeps/sync`** — **`syncTestExecutionTestSteps`** (optional JSON **`body`**; defaults to **`{}`**).
-- **MCP status (v0.16.0):** Implemented as **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**. Core execution create/update/list/remove unchanged (**`execute_test`**, **`get_test_execution`**, etc.).
+- **API:** `GET /testexecutions/{testExecutionIdOrKey}/links` — **`getTestExecutionLinks`**; **`GET .../links/issues`** — **`getTestExecutionIssueLinks`**; **`GET .../teststeps`** — **`getTestExecutionTestSteps`**; **`PUT .../teststeps`** — **`putTestExecutionTestSteps`**; **`POST .../teststeps/sync`** — **`syncTestExecutionTestSteps`** (optional JSON **`body`**; defaults to **`{}`**).
+- **MCP status (v0.16.0+):** **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**. **`update_test_execution_test_steps`** (v0.17.0) wraps **`PUT .../teststeps`** — `steps` array index matches step order; `statusName` e.g. Pass, Fail, In Progress. Core execution create/update/list/remove unchanged (**`execute_test`**, **`get_test_execution`**, etc.).
 
 ### 17. Web link endpoints (not wrapped as MCP tools)
 
@@ -174,7 +174,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 | 15 | Bulk / high-volume reads & batch execution updates | `.../nextgen` GET; no multi-execution PUT in spec | **`list_test_cases_nextgen`**, **`list_test_executions_nextgen`**; **`bulk_execute_tests`** (sequential PUTs, v0.14.0) |
 | 16 | Test case ↔ Jira issue links | GET/POST `.../links` and `.../links/issues` | Implemented (**v0.12.0**); test case, cycle, and plan issue links |
 | 17 | Single test execution retrieval | `GET /testexecutions/{idOrKey}` (`getTestExecution`) | Implemented (**`get_test_execution`**, v0.15.0) |
-| 18 | Execution links and execution test steps | `GET /testexecutions/{id}/links`, `.../links/issues`, `.../teststeps`, `POST .../teststeps/sync` | Implemented (**v0.16.0**): **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`** |
+| 18 | Execution links and execution test steps | `GET /testexecutions/{id}/links`, `.../links/issues`, `.../teststeps`, `PUT .../teststeps`, `POST .../teststeps/sync` | Implemented (**v0.16.0**–**v0.17.0**): **`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, **`update_test_execution_test_steps`** |
 | 19 | Web links on test resources | `POST .../links/weblinks` | Not exposed as MCP tools yet |
 | 20 | Plan ↔ cycle linkage | `POST /testplans/{key}/links/testcycles` | Not exposed as MCP tools yet |
 | 21 | Test case versions | `GET /testcases/{key}/versions` | Not exposed as MCP tools yet |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-zephyr-mcp",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/skills/jira-zephyr-mcp/SKILL.md
+++ b/skills/jira-zephyr-mcp/SKILL.md
@@ -25,7 +25,7 @@ If tools are unavailable, tell the user to add the server per the project README
 | Zephyr projects / folders / priorities / statuses | `list_projects`, `list_folders`, `list_priorities`, `list_statuses` |
 | Test plans | `create_test_plan`, `list_test_plans`, `get_test_plan`, `update_test_plan` |
 | Test cycles | `create_test_cycle`, `list_test_cycles`, `get_test_cycle`, `update_test_cycle`, `add_test_cases_to_cycle` |
-| Executions | `create_test_execution`, `get_test_execution`, `get_test_execution_links`, `get_test_execution_issue_links`, `get_test_execution_test_steps`, `sync_test_execution_test_steps`, `execute_test`, `bulk_execute_tests`, `list_test_executions_in_cycle`, `list_test_executions_nextgen`, `get_test_execution_status`, `remove_test_case_from_cycle`, `generate_test_report` |
+| Executions | `create_test_execution`, `get_test_execution`, `get_test_execution_links`, `get_test_execution_issue_links`, `get_test_execution_test_steps`, `sync_test_execution_test_steps`, `update_test_execution_test_steps`, `execute_test`, `bulk_execute_tests`, `list_test_executions_in_cycle`, `list_test_executions_nextgen`, `get_test_execution_status`, `remove_test_case_from_cycle`, `generate_test_report` |
 | Test cases & steps | `create_test_case`, `search_test_cases`, `list_test_cases_nextgen`, `get_test_case`, `get_test_case_links`, `update_test_case`, `archive_test_case`, `unarchive_test_case`, `delete_test_case`, `create_multiple_test_cases`, `list_test_steps`, `create_test_step`, `update_test_step`, `delete_test_step` |
 | Environments | `list_environments`, `get_environment`, `create_environment`, `update_environment` |
 | Coverage (Jira ↔ Zephyr) | `link_tests_to_issues`, `link_test_cycle_to_issues`, `link_test_plan_to_issues` |
@@ -37,7 +37,8 @@ Prefer **listing** before **creating** when the user did not give keys/IDs. Use 
 1. **Issue linking** — Zephyr expects **numeric Jira Cloud issue id** in `POST .../links/issues` bodies. The MCP tools `link_*_to_issues` accept **issue keys** and resolve them via Jira; do not invent legacy `issueKeys`-only Zephyr payloads.
 2. **Updates that need full bodies** — Test plans, cycles, cases, and environments often use **GET → merge → PUT** on the server. If an update fails with 404/405, the tenant may not expose that route—say so and suggest an alternative (e.g. archive vs delete).
 3. **Regions** — Default Zephyr API host is US; EU and others need `ZEPHYR_BASE_URL` set correctly or calls will fail or hit the wrong tenant.
-4. **Responses** — Tool results are usually JSON strings in MCP content; parse and present clearly. On `success: false`, surface the `error` field.
+4. **Execution results** — Whole case: **`execute_test`** with `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`. Per step: **`update_test_execution_test_steps`** (`steps` array by index; `statusName` e.g. Pass, Fail). Read steps first with **`get_test_execution_test_steps`** when unsure of count/order.
+5. **Responses** — Tool results are usually JSON strings in MCP content; parse and present clearly. On `success: false`, surface the `error` field.
 
 For more detail, load `references/zephyr-jira-conventions.md` in this skill folder when debugging linking, EU/US URLs, or update semantics.
 

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -455,6 +455,19 @@ export class ZephyrClient {
   }
 
   /**
+   * PUT /testexecutions/{id}/teststeps — update per-step execution results (OpenAPI `putTestExecutionTestSteps`).
+   * Array index matches step order; only fields present on each entry are updated. Use `{}` to skip a step.
+   */
+  async updateTestExecutionTestSteps(
+    executionIdOrKey: string,
+    steps: Array<{ statusName?: string; actualResult?: string; comment?: string }>
+  ): Promise<unknown> {
+    const id = encodeURIComponent(executionIdOrKey);
+    const response = await this.client.put(`/testexecutions/${id}/teststeps`, { steps });
+    return response.data;
+  }
+
+  /**
    * Remove a test case from a cycle by deleting its test execution (Scale Cloud v2:
    * DELETE /testexecutions/{id}). Some instances document this poorly; if the API returns
    * 404/405, removal may not be enabled for your tenant.

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   getTestExecutionIssueLinks,
   getTestExecutionTestSteps,
   syncTestExecutionTestSteps,
+  updateTestExecutionTestSteps,
   linkTestsToIssues,
   linkTestCycleToIssues,
   linkTestPlanToIssues,
@@ -63,6 +64,7 @@ import {
   getTestExecutionIssueLinksSchema,
   getTestExecutionTestStepsSchema,
   syncTestExecutionTestStepsSchema,
+  updateTestExecutionTestStepsSchema,
   listTestExecutionsInCycleSchema,
   listTestExecutionsNextgenSchema,
   bulkExecuteTestsSchema,
@@ -112,6 +114,7 @@ import {
   type GetTestExecutionIssueLinksInput,
   type GetTestExecutionTestStepsInput,
   type SyncTestExecutionTestStepsInput,
+  type UpdateTestExecutionTestStepsInput,
   type ListTestExecutionsInCycleInput,
   type ListTestExecutionsNextgenInput,
   type BulkExecuteTestsInput,
@@ -149,7 +152,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.16.1',
+    version: '0.17.0',
   },
   {
     capabilities: {
@@ -419,6 +422,37 @@ const TOOLS = [
         },
       },
       required: ['executionId'],
+    },
+  },
+  {
+    name: 'update_test_execution_test_steps',
+    description:
+      'Update per-step execution results (PUT /testexecutions/{testExecutionIdOrKey}/teststeps, OpenAPI putTestExecutionTestSteps). steps array index matches step order (0 = first step). Only fields you include on each entry are updated; use {} to leave a step unchanged. statusName examples: Pass, Fail, In Progress, Blocked, Not Executed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        executionId: {
+          type: 'string',
+          description: 'Test execution id or key (from list_test_executions_in_cycle or get_test_execution)',
+        },
+        steps: {
+          type: 'array',
+          description:
+            'One object per execution step in order. Each may include statusName, actualResult, comment (all optional).',
+          items: {
+            type: 'object',
+            properties: {
+              statusName: {
+                type: 'string',
+                description: 'Step status (e.g. Pass, Fail, In Progress, Blocked, Not Executed)',
+              },
+              actualResult: { type: 'string', description: 'Observed result for this step' },
+              comment: { type: 'string', description: 'Step comment' },
+            },
+          },
+        },
+      },
+      required: ['executionId', 'steps'],
     },
   },
   {
@@ -1233,6 +1267,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(await syncTestExecutionTestSteps(validatedArgs), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'update_test_execution_test_steps': {
+        const validatedArgs = validateInput<UpdateTestExecutionTestStepsInput>(
+          updateTestExecutionTestStepsSchema,
+          args,
+          'update_test_execution_test_steps'
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(await updateTestExecutionTestSteps(validatedArgs), null, 2),
             },
           ],
         };

--- a/src/tools/test-execution.ts
+++ b/src/tools/test-execution.ts
@@ -14,6 +14,7 @@ import {
   getTestExecutionIssueLinksSchema,
   getTestExecutionTestStepsSchema,
   syncTestExecutionTestStepsSchema,
+  updateTestExecutionTestStepsSchema,
   listTestExecutionsInCycleSchema,
   listTestExecutionsNextgenSchema,
   bulkExecuteTestsSchema,
@@ -30,6 +31,7 @@ import {
   type GetTestExecutionIssueLinksInput,
   type GetTestExecutionTestStepsInput,
   type SyncTestExecutionTestStepsInput,
+  type UpdateTestExecutionTestStepsInput,
   type ListTestExecutionsInCycleInput,
   type ListTestExecutionsNextgenInput,
   type BulkExecuteTestsInput,
@@ -286,6 +288,19 @@ export const syncTestExecutionTestSteps = async (input: SyncTestExecutionTestSte
       validatedInput.body
     );
     return { success: true, data };
+  } catch (error: unknown) {
+    return zephyrToolFailure(error, { permissionCategories: ['edit'] });
+  }
+};
+
+export const updateTestExecutionTestSteps = async (input: UpdateTestExecutionTestStepsInput) => {
+  const validatedInput = updateTestExecutionTestStepsSchema.parse(input);
+  try {
+    const data = await getZephyrClient().updateTestExecutionTestSteps(
+      validatedInput.executionId.trim(),
+      validatedInput.steps
+    );
+    return { success: true, data: data ?? {} };
   } catch (error: unknown) {
     return zephyrToolFailure(error, { permissionCategories: ['edit'] });
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -124,6 +124,21 @@ export const syncTestExecutionTestStepsSchema = z.object({
   body: z.record(z.string(), z.any()).optional(),
 });
 
+/** One step patch for PUT /testexecutions/{idOrKey}/teststeps — OpenAPI `putTestExecutionTestSteps`. */
+export const testExecutionStepPatchSchema = z.object({
+  statusName: z.string().optional(),
+  actualResult: z.string().optional(),
+  comment: z.string().optional(),
+});
+
+/** PUT /testexecutions/{idOrKey}/teststeps — OpenAPI `putTestExecutionTestSteps`. */
+export const updateTestExecutionTestStepsSchema = z.object({
+  executionId: z.string().min(1, 'Test execution id or key is required'),
+  steps: z
+    .array(testExecutionStepPatchSchema)
+    .min(1, 'At least one step entry is required (use {} to leave a step unchanged)'),
+});
+
 export const listTestExecutionsInCycleSchema = z.object({
   cycleId: z.string().min(1, 'Cycle ID or key is required'),
 });
@@ -419,6 +434,7 @@ export type GetTestExecutionLinksInput = z.infer<typeof getTestExecutionLinksSch
 export type GetTestExecutionIssueLinksInput = z.infer<typeof getTestExecutionIssueLinksSchema>;
 export type GetTestExecutionTestStepsInput = z.infer<typeof getTestExecutionTestStepsSchema>;
 export type SyncTestExecutionTestStepsInput = z.infer<typeof syncTestExecutionTestStepsSchema>;
+export type UpdateTestExecutionTestStepsInput = z.infer<typeof updateTestExecutionTestStepsSchema>;
 export type ListTestExecutionsInCycleInput = z.infer<typeof listTestExecutionsInCycleSchema>;
 export type ListTestExecutionsNextgenInput = z.infer<typeof listTestExecutionsNextgenSchema>;
 export type ListTestCasesNextgenInput = z.infer<typeof listTestCasesNextgenSchema>;

--- a/tests/tools-handlers.test.ts
+++ b/tests/tools-handlers.test.ts
@@ -33,6 +33,7 @@ import {
   getTestExecutionIssueLinks,
   getTestExecutionTestSteps,
   syncTestExecutionTestSteps,
+  updateTestExecutionTestSteps,
   bulkExecuteTests,
   generateTestReport,
   createTestExecution,
@@ -701,6 +702,32 @@ describe('tool handlers (smoke, mocked)', () => {
     const r = await syncTestExecutionTestSteps({ executionId: 'ex-sync' });
     expect(r.success).toBe(true);
     if (r.success) expect(r.data).toEqual({ done: true });
+  });
+
+  it('update_test_execution_test_steps puts step results', async () => {
+    nock(ZEPHYR_ORIGIN)
+      .put(`${V2}/testexecutions/ex-put/teststeps`, {
+        steps: [{ statusName: 'Pass' }, { statusName: 'Fail', actualResult: 'broken' }],
+      })
+      .reply(200, {});
+    const r = await updateTestExecutionTestSteps({
+      executionId: 'ex-put',
+      steps: [{ statusName: 'Pass' }, { statusName: 'Fail', actualResult: 'broken' }],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual({});
+  });
+
+  it('update_test_execution_test_steps returns error when Zephyr fails', async () => {
+    nock(ZEPHYR_ORIGIN)
+      .put(`${V2}/testexecutions/bad-steps/teststeps`, () => true)
+      .reply(400, { message: 'invalid steps' });
+    const r = await updateTestExecutionTestSteps({
+      executionId: 'bad-steps',
+      steps: [{ statusName: 'Pass' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.errorInfo?.kind).toBe('validation');
   });
 
   it('get_test_execution returns a single execution row', async () => {

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -809,6 +809,19 @@ describe('ZephyrClient (integration, mocked)', () => {
       expect(scope.isDone()).toBe(true);
     });
 
+    it('sends PUT /v2/testexecutions/{id}/teststeps with steps array', async () => {
+      const body = {};
+      const steps = [{ statusName: 'Pass', actualResult: 'ok' }, { statusName: 'Fail' }];
+      const scope = nock(ZEPHYR_ORIGIN)
+        .put(`${V2}/testexecutions/ex-steps/teststeps`, (b: { steps?: unknown }) => {
+          const s = b.steps as typeof steps;
+          return s?.length === 2 && s[0].statusName === 'Pass' && s[1].statusName === 'Fail';
+        })
+        .reply(200, body);
+      await expect(client.updateTestExecutionTestSteps('ex-steps', steps)).resolves.toEqual(body);
+      expect(scope.isDone()).toBe(true);
+    });
+
     it('encodes execution id in path segments', async () => {
       const encoded = encodeURIComponent('E/1');
       const scope = nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions/${encoded}/links`).reply(200, {});


### PR DESCRIPTION
## Summary

Minor release **0.17.0** adds **`update_test_execution_test_steps`** — wraps OpenAPI **`putTestExecutionTestSteps`** (`PUT /testexecutions/{id}/teststeps`). Agents can set **per-step** `statusName` (Pass, Fail, In Progress, Blocked, Not Executed), `actualResult`, and `comment`. Array index matches step order; `{}` leaves a step unchanged.

**Label:** `tag-minor` → expect git tag **`v0.17.0`** on merge (from **`v0.16.1`**).

## New MCP tool

| Tool | API |
|------|-----|
| **update_test_execution_test_steps** | `PUT /testexecutions/{testExecutionIdOrKey}/teststeps` |

```ts
update_test_execution_test_steps({
  executionId: "PROJ-E1",
  steps: [
    { statusName: "Pass", actualResult: "Step 1 ok" },
    { statusName: "Fail", actualResult: "Assertion failed" },
  ],
});
```

## Execution status (unchanged tools)

| Scope | Tool | Values |
|-------|------|--------|
| Whole execution | **`execute_test`** | `PASS`, `FAIL`, `WIP` (In progress), `BLOCKED` |
| Per step | **`update_test_execution_test_steps`** | UI `statusName` strings |

## Documentation

- **README** — tools table, known limitations, roadmap, examples
- **docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md** — §16, §23, summary rows #18 / #25
- **CLAUDE.md**, **AGENTS.md**, **skills/jira-zephyr-mcp/SKILL.md**

## Tests

- Nock tests for **`ZephyrClient.updateTestExecutionTestSteps`** and handler (success + error paths)

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (194 passed)
- [x] `npm run build`
- [ ] CI green on merge commit

## Release notes (for v0.17.0)

See PR merge → tag **`v0.17.0`** → GitHub Release body (same structure as [v0.16.0](https://github.com/miklosbagi/jira-zephyr-mcp/releases/tag/v0.16.0)).