### PR TITLE
feat: execution environmentName on update — v0.18.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Optional: `ZEPHYR_BASE_URL` (default US Scale API; **EU:** `https://eu.api.zephy
 - Resolve keys: Jira **`GET /rest/api/3/issue/{key}`** (fields can include `id`), then POST to Zephyr.
 - **PUT** endpoints often need **full merged bodies** after GET (test cases, cycles, environments) — see existing client methods.
 - **Attachments:** No public Scale Cloud v2 routes — do not implement private TM4J/S3 flows without explicit request ([issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118); gaps doc §22).
-- **Execution status:** `execute_test` uses `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`. Per-step: **`update_test_execution_test_steps`** (v0.17.0).
+- **Execution status:** `execute_test` uses `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`; optional `environmentName` on update (v0.18.0). Per-step: **`update_test_execution_test_steps`** (v0.17.0).
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ The following environment variables are required:
 - `list_test_cycles`: List existing test cycles with execution status
 - `get_test_cycle`: Get one test cycle by key or id
 - `update_test_cycle`: Update a test cycle (`PUT /testcycles/{key}`; GET-merge-PUT, including status, version, owner, custom fields)
-- `execute_test`: Update test execution results
-- `bulk_execute_tests`: Update many executions sequentially (one PUT each; no single bulk API in public spec)
+- `execute_test`: Update test execution results (status, comment, defects, optional environmentName)
+- `bulk_execute_tests`: Update many executions sequentially (one PUT each; no single bulk API in public spec); each item may include environmentName
 - `list_test_executions_nextgen`: Cursor-paged list of executions (`GET /testexecutions/nextgen`)
 - `get_test_execution`: Get one execution by id or key (`GET /testexecutions/{idOrKey}`, OpenAPI `getTestExecution`)
 - `get_test_execution_links`: List web links for an execution (`GET /testexecutions/{id}/links`, OpenAPI `getTestExecutionLinks`)

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ When using the Docker image, pass these via your MCP config’s `env` (as in Qui
 | **create_test_case** / **search_test_cases** / **list_test_cases_nextgen** / **get_test_case** / **update_test_case** / **create_multiple_test_cases** | Full test case lifecycle: create, search, cursor list ([`GET /testcases/nextgen`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/listTestCasesCursorPaginated)), get, update (including custom fields), bulk create. Test script types: STEP_BY_STEP (default), PLAIN_TEXT, CUCUMBER. |
 | **archive_test_case** / **unarchive_test_case** / **delete_test_case** | Archive via PUT (`archived` flag), unarchive, or DELETE. **API support varies** — some instances reject `archived` or DELETE; see [ZEPHYR-SCALE-CLOUD-API-GAPS.md](docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md). |
 | **list_test_steps** / **create_test_step** / **update_test_step** / **delete_test_step** | Manage test steps for a test case independently (step-by-step scripts). |
-| **execute_test** | Update one test execution status: **`PASS`**, **`FAIL`**, **`WIP`** (In progress), or **`BLOCKED`** via `PUT /testexecutions/{id}`. Use **`WIP`** to move from Not executed to In progress. |
-| **bulk_execute_tests** | Update many executions **sequentially** (one `PUT /testexecutions/{id}` per item). The public API has **no** single bulk-update call; optional `continueOnError` (default true), same idea as `create_multiple_test_cases`. |
+| **execute_test** | Update one test execution: **`PASS`**, **`FAIL`**, **`WIP`** (In progress), or **`BLOCKED`** via `PUT /testexecutions/{id}`. Optional **`environmentName`** to set or change the environment on an existing execution. Use **`WIP`** to move from Not executed to In progress. |
+| **bulk_execute_tests** | Update many executions **sequentially** (one `PUT /testexecutions/{id}` per item). Each item may include **`environmentName`**. The public API has **no** single bulk-update call; optional `continueOnError` (default true), same idea as `create_multiple_test_cases`. |
 | **get_test_execution_status** | Execution progress and stats for a cycle. |
 | **link_tests_to_issues** | Link a test case to Jira issue(s) as **coverage** ([`POST .../testcases/{key}/links/issues`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/createTestCaseIssueLink)). Resolves each issue **key** to a numeric id via Jira REST, then calls Zephyr (v0.12.0; replaces the old `POST .../links` + `issueKeys` shape). |
 | **get_test_case_links** | List Jira issue links and web links for a test case ([`GET .../testcases/{key}/links`](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#tag/Test-Cases/operation/getTestCaseLinks)). |
@@ -171,6 +171,7 @@ Documented gaps between Zephyr Scale Cloud and this MCP server. Full detail: [do
 |-------|-----------|--------|
 | **Attachments** (screenshots, GIFs, evidence) | No tools | Public Scale API v2 has no attachment upload/download routes on Cloud. [Issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118). Workarounds: Jira issue attachments on linked defects; URLs in execution comments; UI upload. |
 | **Per-step Pass/Fail on executions** | **`update_test_execution_test_steps`** | Per-step `statusName` (Pass, Fail, In Progress, Blocked, Not Executed), `actualResult`, `comment`. Read first with **`get_test_execution_test_steps`**. Whole-execution status: **`execute_test`**. |
+| **Execution environment** | **`execute_test`** / **`bulk_execute_tests`** | Optional **`environmentName`** on update (v0.18.0). Also set at create via **`create_test_execution`**. Use **`list_environments`** for valid names. |
 | **Execution status** | **`execute_test`** | **`WIP`** = In progress. **`PASS`** / **`FAIL`** / **`BLOCKED`** for final states. Cannot set back to Not executed via API update. |
 | **BDD script type** | Plain text / step-by-step only | BDD (Gherkin) requires UI or unsupported TM4J backend — see gaps doc §11b. |
 
@@ -275,8 +276,8 @@ delete_test_step({ testCaseKey: "ABC-T123", stepId: 2 });
 **Execution and reporting**
 ```ts
 get_test_execution({ executionId: "12345" });
-execute_test({ executionId: "12345", status: "PASS", comment: "All passed" });
-bulk_execute_tests({ executions: [{ executionId: "12345", status: "PASS" }, { executionId: "12346", status: "FAIL" }], continueOnError: true });
+execute_test({ executionId: "12345", status: "PASS", comment: "All passed", environmentName: "Staging" });
+bulk_execute_tests({ executions: [{ executionId: "12345", status: "PASS", environmentName: "Staging" }, { executionId: "12346", status: "FAIL" }], continueOnError: true });
 get_test_execution_status({ cycleId: "67890" });
 link_tests_to_issues({ testCaseId: "ABC-T123", issueKeys: ["ABC-456"] });
 link_test_cycle_to_issues({ cycleKey: "ABC-R1", issueKeys: ["ABC-456"] });

--- a/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
+++ b/docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md
@@ -10,7 +10,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 |------|-------------|
 | **Test plans** | Create, list (by projectKey), get one, update (**`update_test_plan`**: GET-merge-PUT — **not** in public OpenAPI; see §14) |
 | **Test cycles** | Create, list (by projectKey, optional versionId), get one, **`update_test_cycle`** (PUT `testcycles/{key}`, OpenAPI `updateTestCycle`) |
-| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), **links & steps** (**`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, **`update_test_execution_test_steps`**, v0.16.0–v0.17.0), update status/comment/defects (**`execute_test`**: `PASS`/`FAIL`/`WIP`/In progress/`BLOCKED`), list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
+| **Test executions** | Create (add test case to cycle), **get one** (**`get_test_execution`**, `GET /testexecutions/{idOrKey}`, v0.15.0), **links & steps** (**`get_test_execution_links`**, **`get_test_execution_issue_links`**, **`get_test_execution_test_steps`**, **`sync_test_execution_test_steps`**, **`update_test_execution_test_steps`**, v0.16.0–v0.17.0), update status/comment/defects/**environment** (**`execute_test`**: `PASS`/`FAIL`/`WIP`/In progress/`BLOCKED`, optional **`environmentName`** v0.18.0), list in cycle, cursor list (**`list_test_executions_nextgen`**, v0.14.0), summary by cycle, **`bulk_execute_tests`** (sequential PUTs — not one API call) |
 | **Test cases** | Get one, search, cursor list (**`list_test_cases_nextgen`**, v0.14.0), create, update, create multiple |
 | **Folders** | List (by projectKey, optional folderType, parentId), create (with optional parentId, folderType) |
 | **Priorities / statuses** | List priorities and statuses (GET /priorities, GET /statuses; optional projectKey) for test case create/update |
@@ -111,7 +111,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 ### 15. **Bulk or batch operations**
 
 - **API (OpenAPI):** There is **no** documented endpoint that accepts **multiple test execution updates in one request**. **`GET /testcases/nextgen`** (`listTestCasesCursorPaginated`) and **`GET /testexecutions/nextgen`** (`listTestExecutionsNextgen`) are **cursor-paged list** APIs for **large read volumes** (use `nextStartAtId` / `next` for the next page). **`POST /testcycles/{key}/testcases`** with an `items` array adds several cases to a cycle in one call — already exposed as **`add_test_cases_to_cycle`** (may 404 on some regions).
-- **MCP status (v0.14.0+):** **`list_test_cases_nextgen`** and **`list_test_executions_nextgen`** call the documented nextgen GET routes. **`bulk_execute_tests`** applies the same payload as **`execute_test`** via **sequential `PUT /testexecutions/{id}`** calls (optional **`continueOnError`**, same pattern as **`create_multiple_test_cases`**). For very large batches, prefer external orchestration or rate limits to avoid throttling.
+- **MCP status (v0.14.0+):** **`list_test_cases_nextgen`** and **`list_test_executions_nextgen`** call the documented nextgen GET routes. **`bulk_execute_tests`** applies the same payload as **`execute_test`** via **sequential `PUT /testexecutions/{id}`** calls (optional **`continueOnError`**, same pattern as **`create_multiple_test_cases`**). **`execute_test`** / **`bulk_execute_tests`** accept optional **`environmentName`** on update (v0.18.0; OpenAPI `TestExecutionUpdate`). For very large batches, prefer external orchestration or rate limits to avoid throttling.
 
 ### 16. Additional test execution endpoints (links, steps, sync)
 
@@ -162,7 +162,7 @@ This document lists **Zephyr Scale for Jira Cloud API** capabilities that are **
 ### 23. **Update execution step results (per-step Pass / Fail / In progress)**
 
 - **Implemented (v0.17.0):** **`update_test_execution_test_steps`** — see §16. **`get_test_execution_test_steps`** / **`sync_test_execution_test_steps`** (v0.16.0) remain read/sync only.
-- **Whole-execution status:** **`execute_test`** / **`bulk_execute_tests`** — `PASS`, `FAIL`, `WIP` (In progress), `BLOCKED`. No `NOT_EXECUTED` on update.
+- **Whole-execution status:** **`execute_test`** / **`bulk_execute_tests`** — `PASS`, `FAIL`, `WIP` (In progress), `BLOCKED`. Optional **`environmentName`** to assign or change environment on an existing execution (v0.18.0). No `NOT_EXECUTED` on update.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-zephyr-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for integrating with JIRA's Zephyr test management system",
   "main": "dist/index.js",
   "type": "module",

--- a/skills/jira-zephyr-mcp/SKILL.md
+++ b/skills/jira-zephyr-mcp/SKILL.md
@@ -37,7 +37,7 @@ Prefer **listing** before **creating** when the user did not give keys/IDs. Use 
 1. **Issue linking** — Zephyr expects **numeric Jira Cloud issue id** in `POST .../links/issues` bodies. The MCP tools `link_*_to_issues` accept **issue keys** and resolve them via Jira; do not invent legacy `issueKeys`-only Zephyr payloads.
 2. **Updates that need full bodies** — Test plans, cycles, cases, and environments often use **GET → merge → PUT** on the server. If an update fails with 404/405, the tenant may not expose that route—say so and suggest an alternative (e.g. archive vs delete).
 3. **Regions** — Default Zephyr API host is US; EU and others need `ZEPHYR_BASE_URL` set correctly or calls will fail or hit the wrong tenant.
-4. **Execution results** — Whole case: **`execute_test`** with `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`. Per step: **`update_test_execution_test_steps`** (`steps` array by index; `statusName` e.g. Pass, Fail). Read steps first with **`get_test_execution_test_steps`** when unsure of count/order.
+4. **Execution results** — Whole case: **`execute_test`** with `PASS` | `FAIL` | `WIP` (In progress) | `BLOCKED`; optional **`environmentName`** to set or change environment on an existing execution (v0.18.0). Per step: **`update_test_execution_test_steps`** (`steps` array by index; `statusName` e.g. Pass, Fail). Read steps first with **`get_test_execution_test_steps`** when unsure of count/order.
 5. **Responses** — Tool results are usually JSON strings in MCP content; parse and present clearly. On `success: false`, surface the `error` field.
 
 ## Known limitations (agents)
@@ -45,6 +45,7 @@ Prefer **listing** before **creating** when the user did not give keys/IDs. Use 
 | Need | Use instead |
 |------|-------------|
 | Upload screenshot/GIF evidence to a test execution | **Not supported** — [issue #118](https://github.com/miklosbagi/jira-zephyr-mcp/issues/118). Attach to linked Jira defects or put artifact URLs in `execute_test` **comment**. |
+| Change **environment** on an execution in a cycle | **`execute_test`** or **`bulk_execute_tests`** with optional **`environmentName`** (v0.18.0). Also at create: **`create_test_execution`**. Use **`list_environments`** for names. |
 | Mark execution **In progress** from Not executed | **`execute_test`** with **`status: "WIP"`** (same as In progress in Zephyr). |
 | Set each **step** to Pass/Fail / In progress / Blocked / Not executed | **`update_test_execution_test_steps`** with `statusName` per step (UI labels, e.g. Pass, Fail, In Progress). |
 | Set execution back to Not executed | **Not via `execute_test`** — only `PASS` / `FAIL` / `WIP` / `BLOCKED` on update. |

--- a/src/clients/zephyr-client.ts
+++ b/src/clients/zephyr-client.ts
@@ -514,12 +514,16 @@ export class ZephyrClient {
     status: 'PASS' | 'FAIL' | 'WIP' | 'BLOCKED';
     comment?: string;
     defects?: string[];
+    environmentName?: string;
   }): Promise<ZephyrTestExecution> {
-    const payload = {
+    const payload: Record<string, unknown> = {
       status: data.status,
       comment: data.comment,
       issues: data.defects?.map(key => ({ key })),
     };
+    if (data.environmentName !== undefined) {
+      payload.environmentName = data.environmentName;
+    }
 
     const response = await this.client.put(`/testexecutions/${data.executionId}`, payload);
     return response.data;
@@ -575,6 +579,7 @@ export class ZephyrClient {
       status: 'PASS' | 'FAIL' | 'WIP' | 'BLOCKED';
       comment?: string;
       defects?: string[];
+      environmentName?: string;
     }>,
     continueOnError = true
   ): Promise<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ import {
 const server = new Server(
   {
     name: 'jira-zephyr-mcp',
-    version: '0.17.0',
+    version: '0.18.0',
   },
   {
     capabilities: {
@@ -507,7 +507,8 @@ const TOOLS = [
   },
   {
     name: 'execute_test',
-    description: 'Update test execution results',
+    description:
+      'Update test execution results (status, comment, defects, environment). Optional environmentName sets or changes the environment assigned to this execution in the cycle (OpenAPI updateTestExecution).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -515,6 +516,11 @@ const TOOLS = [
         status: { type: 'string', enum: ['PASS', 'FAIL', 'WIP', 'BLOCKED'], description: 'Execution status' },
         comment: { type: 'string', description: 'Execution comment (optional)' },
         defects: { type: 'array', items: { type: 'string' }, description: 'Linked defect keys (optional)' },
+        environmentName: {
+          type: 'string',
+          description:
+            'Environment name for this execution (optional). Use list_environments for valid names; same field as create_test_execution environmentName.',
+        },
       },
       required: ['executionId', 'status'],
     },
@@ -522,13 +528,14 @@ const TOOLS = [
   {
     name: 'bulk_execute_tests',
     description:
-      'Update many test executions sequentially (one PUT per item). The public API has no single bulk-update endpoint; mirrors create_multiple_test_cases. Optional continueOnError (default true).',
+      'Update many test executions sequentially (one PUT per item). The public API has no single bulk-update endpoint; mirrors create_multiple_test_cases. Optional continueOnError (default true). Each item supports optional environmentName.',
     inputSchema: {
       type: 'object',
       properties: {
         executions: {
           type: 'array',
-          description: 'Each item: executionId, status (PASS|FAIL|WIP|BLOCKED), optional comment and defects',
+          description:
+            'Each item: executionId, status (PASS|FAIL|WIP|BLOCKED), optional comment, defects, and environmentName',
           items: {
             type: 'object',
             properties: {
@@ -536,6 +543,7 @@ const TOOLS = [
               status: { type: 'string', enum: ['PASS', 'FAIL', 'WIP', 'BLOCKED'] },
               comment: { type: 'string' },
               defects: { type: 'array', items: { type: 'string' } },
+              environmentName: { type: 'string', description: 'Environment name (optional)' },
             },
             required: ['executionId', 'status'],
           },

--- a/src/tools/test-execution.ts
+++ b/src/tools/test-execution.ts
@@ -112,6 +112,7 @@ export const executeTest = async (input: ExecuteTestInput) => {
       status: validatedInput.status,
       comment: validatedInput.comment,
       defects: validatedInput.defects,
+      environmentName: validatedInput.environmentName,
     });
     
     return {
@@ -122,10 +123,11 @@ export const executeTest = async (input: ExecuteTestInput) => {
         cycleId: execution.cycleId,
         testCaseId: execution.testCaseId,
         status: execution.status,
+        environmentName: execution.environmentName,
         comment: execution.comment,
         executedOn: execution.executedOn,
         executedBy: execution.executedBy?.displayName,
-        defects: execution.defects.map(defect => ({
+        defects: execution.defects?.map(defect => ({
           key: defect.key,
           summary: defect.summary,
         })),
@@ -327,6 +329,7 @@ export const bulkExecuteTests = async (input: BulkExecuteTestsInput) => {
                   cycleId: r.data.cycleId,
                   testCaseId: r.data.testCaseId,
                   status: r.data.status,
+                  environmentName: r.data.environmentName,
                   comment: r.data.comment,
                   executedOn: r.data.executedOn,
                   executedBy: r.data.executedBy?.displayName,

--- a/src/types/zephyr-types.ts
+++ b/src/types/zephyr-types.ts
@@ -58,6 +58,7 @@ export interface ZephyrTestExecution {
   cycleId: string;
   testCaseId: string;
   status: 'PASS' | 'FAIL' | 'WIP' | 'BLOCKED' | 'NOT_EXECUTED';
+  environmentName?: string;
   comment?: string;
   executedOn?: string;
   executedBy?: {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -92,6 +92,7 @@ export const executeTestSchema = z.object({
   status: z.enum(['PASS', 'FAIL', 'WIP', 'BLOCKED']),
   comment: z.string().optional(),
   defects: z.array(z.string()).optional(),
+  environmentName: z.string().optional(),
 });
 
 export const getTestExecutionStatusSchema = z.object({
@@ -170,6 +171,7 @@ const singleExecutionUpdateSchema = z.object({
   status: z.enum(['PASS', 'FAIL', 'WIP', 'BLOCKED']),
   comment: z.string().optional(),
   defects: z.array(z.string()).optional(),
+  environmentName: z.string().optional(),
 });
 
 /** Sequential PUTs; no single bulk endpoint in the public API. */

--- a/tests/tools-handlers.test.ts
+++ b/tests/tools-handlers.test.ts
@@ -245,6 +245,19 @@ describe('tool handlers (smoke, mocked)', () => {
       expect(execOut.data?.defects).toEqual([{ key: 'BUG-1', summary: 'Defect summary' }]);
     }
 
+    nock(ZEPHYR_ORIGIN)
+      .put(`${V2}/testexecutions/e2`, (b: Record<string, unknown>) => b.environmentName === 'Staging')
+      .reply(200, { ...ex, key: 'E2', environmentName: 'Staging' });
+    const envOut = await executeTest({
+      executionId: 'e2',
+      status: 'WIP',
+      environmentName: 'Staging',
+    });
+    expect(envOut.success).toBe(true);
+    if (envOut.success) {
+      expect(envOut.data?.environmentName).toBe('Staging');
+    }
+
     nock(ZEPHYR_ORIGIN).get(`${V2}/testexecutions`).query({ testCycle: 'C1' }).reply(200, {
       values: [{ status: 'PASS' }],
       total: 1,

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -124,6 +124,13 @@ describe('validation schemas', () => {
         status: 'PASS',
       })
     ).toMatchObject({ executionId: 'e1', status: 'PASS' });
+    expect(
+      executeTestSchema.parse({
+        executionId: 'e1',
+        status: 'WIP',
+        environmentName: 'Staging',
+      })
+    ).toMatchObject({ environmentName: 'Staging' });
   });
 
   it('getTestExecutionStatusSchema', () => {
@@ -149,6 +156,11 @@ describe('validation schemas', () => {
         executions: [{ executionId: 'e1', status: 'PASS' }],
       })
     ).toMatchObject({ continueOnError: true });
+    expect(
+      bulkExecuteTestsSchema.parse({
+        executions: [{ executionId: 'e1', status: 'PASS', environmentName: 'Production' }],
+      }).executions[0]
+    ).toMatchObject({ environmentName: 'Production' });
   });
 
   it('addTestCasesToCycleSchema', () => {

--- a/tests/zephyr-client.test.ts
+++ b/tests/zephyr-client.test.ts
@@ -766,6 +766,20 @@ describe('ZephyrClient (integration, mocked)', () => {
       });
       expect(u.status).toBe('PASS');
       expect(scope.isDone()).toBe(true);
+
+      const envScope = nock(ZEPHYR_ORIGIN)
+        .put(
+          `${V2}/testexecutions/e1`,
+          (b: Record<string, unknown>) => b.status === 'WIP' && b.environmentName === 'Staging'
+        )
+        .reply(200, { ...ex, status: 'WIP', environmentName: 'Staging' });
+      const withEnv = await client.updateTestExecution({
+        executionId: 'e1',
+        status: 'WIP',
+        environmentName: 'Staging',
+      });
+      expect(withEnv.environmentName).toBe('Staging');
+      expect(envScope.isDone()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- **`execute_test`** and **`bulk_execute_tests`** accept optional **`environmentName`** to set or change the environment assigned to a test execution in a cycle (`PUT /testexecutions/{id}`, OpenAPI `TestExecutionUpdate`).
- Response includes **`environmentName`** when the API returns it.
- Version bump to **0.18.0** (`package.json`, MCP `serverInfo.version`).

## Why

Agents need to update execution environment after a case is already in a cycle. Previously only **`create_test_execution`** could set `environmentName` at add time.

## New / changed MCP tools

| Tool | Change |
|------|--------|
| **`execute_test`** | Optional `environmentName` parameter |
| **`bulk_execute_tests`** | Each execution item may include `environmentName` |

## Tests

- `tests/zephyr-client.test.ts` — PUT payload includes `environmentName`
- `tests/tools-handlers.test.ts` — handler passes through and returns environment
- `tests/validation.test.ts` — schema accepts optional `environmentName`

## Documentation

- `README.md`, `CLAUDE.md`, `AGENTS.md`, `skills/jira-zephyr-mcp/SKILL.md`, `docs/ZEPHYR-SCALE-CLOUD-API-GAPS.md`

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage`
- [x] `npm run build`

## Upgrade notes

After merge and **`docker pull miklosbagi/jira-zephyr-mcp:latest`**, restart the MCP host. Example:

```json
execute_test({
  "executionId": "12345",
  "status": "WIP",
  "environmentName": "Staging"
})
```

Use **`list_environments`** for valid project environment names.