### PR TITLE
fix(security): pin brace-expansion >=5.0.6 via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,6 +2135,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2164,7 +2166,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3703,11 +3707,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Addresses two MODERATE-severity DoS vulnerabilities in `brace-expansion` that were reachable through the `minimatch` → `eslint`/`typescript-eslint` transitive chain.

## Fixes

| Advisory | Severity | Description |
|----------|----------|-------------|
| [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) | MODERATE | Zero-step sequence causes process hang and memory exhaustion |
| [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) | MODERATE | Large numeric range defeats documented `max` DoS protection |

**Before:** `brace-expansion@5.0.4` (vulnerable range `>=5.0.0 <5.0.6`)  
**After:** `brace-expansion@5.0.7` via `npm overrides` pin `^5.0.6`

## Approach

Adds `overrides.brace-expansion: ^5.0.6` to `package.json`. This is a lockfile-level fix — no direct dependency on `brace-expansion` is added. The override forces all transitive consumers (`minimatch` → `@eslint/config-array`, `eslint`, `@typescript-eslint/typescript-estree`) to use the patched version.

## Remaining known issue

`esbuild@0.27.4` — LOW severity ([GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr)), arbitrary file read via dev server on Windows only. Blocked upstream: `tsup@8.5.1` (latest) pins `esbuild ^0.27.0`. Not exploitable in this MCP server (no dev server, not Windows-specific path). Will resolve automatically when `tsup` upgrades its esbuild peer.

## Tests

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:coverage` — 13 test files, 201 passed, 99.28% statement coverage